### PR TITLE
chore: enable Laravel API routes

### DIFF
--- a/apps/api/bootstrap/app.php
+++ b/apps/api/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/health', function () {
+    return response()->json([
+        'success' => true,
+        'message' => 'API is running',
+        'data' => [
+            'app' => config('app.name'),
+            'environment' => app()->environment(),
+        ],
+    ]);
+});


### PR DESCRIPTION
## Summary

Configured Laravel API routing foundation.

## Changes

- Added `routes/api.php`
- Registered API routes in `bootstrap/app.php`
- Added `/api/health` endpoint
- Verified Laravel runs inside Docker
- Verified MySQL connection works

## Testing

- `docker compose exec api php artisan route:list --path=api`
- `docker compose exec api php artisan about`
- `docker compose exec api php artisan migrate:status`
- `curl http://localhost:8000/api/health`

## Notes

Auth, Sanctum, models, migrations, and business endpoints are intentionally left for later issues.