### PR TITLE
feat: add model factories

### DIFF
--- a/apps/api/database/factories/CommentFactory.php
+++ b/apps/api/database/factories/CommentFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Comment;
+use App\Models\Task;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Comment>
+ */
+class CommentFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'task_id' => Task::factory(),
+            'user_id' => User::factory(),
+            'body' => fake()->paragraph(),
+        ];
+    }
+}

--- a/apps/api/database/factories/PermissionFactory.php
+++ b/apps/api/database/factories/PermissionFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Permission;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Permission>
+ */
+class PermissionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $group = fake()->randomElement(['workspace', 'team', 'project', 'task']);
+        $action = fake()->randomElement(['view', 'create', 'update', 'delete', 'manage']).'-'.fake()->unique()->numberBetween(1000, 9999);
+        $name = $group.'.'.$action;
+
+        return [
+            'name' => $name,
+            'group' => $group,
+            'description' => Str::headline($name).' permission.',
+        ];
+    }
+}

--- a/apps/api/database/factories/ProjectFactory.php
+++ b/apps/api/database/factories/ProjectFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Project;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Project>
+ */
+class ProjectFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->unique()->words(3, true);
+
+        return [
+            'workspace_id' => Workspace::factory(),
+            'team_id' => fn (array $attributes) => Team::factory()->create([
+                'workspace_id' => $attributes['workspace_id'],
+            ])->id,
+            'created_by' => User::factory(),
+            'name' => Str::title($name),
+            'slug' => Str::slug($name).'-'.fake()->unique()->numberBetween(1000, 9999),
+            'description' => fake()->optional()->paragraph(),
+            'starts_at' => fake()->optional()->dateTimeBetween('-1 month', '+1 month'),
+            'ends_at' => fake()->optional()->dateTimeBetween('+1 month', '+6 months'),
+        ];
+    }
+}

--- a/apps/api/database/factories/RoleFactory.php
+++ b/apps/api/database/factories/RoleFactory.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Role;
+use App\Models\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Role>
+ */
+class RoleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->unique()->jobTitle();
+
+        return [
+            'workspace_id' => Workspace::factory(),
+            'name' => $name,
+            'slug' => Str::slug($name).'-'.fake()->unique()->numberBetween(1000, 9999),
+            'level' => fake()->numberBetween(10, 90),
+            'is_system' => false,
+            'description' => fake()->optional()->sentence(),
+        ];
+    }
+
+    public function admin(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'name' => 'Admin',
+            'slug' => 'admin',
+            'level' => 100,
+            'is_system' => true,
+        ]);
+    }
+
+    public function teamLead(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'name' => 'Team Lead',
+            'slug' => 'team-lead',
+            'level' => 80,
+            'is_system' => true,
+        ]);
+    }
+
+    public function senior(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'name' => 'Senior',
+            'slug' => 'senior',
+            'level' => 60,
+            'is_system' => true,
+        ]);
+    }
+
+    public function mid(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'name' => 'Mid',
+            'slug' => 'mid',
+            'level' => 40,
+            'is_system' => true,
+        ]);
+    }
+
+    public function junior(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'name' => 'Junior',
+            'slug' => 'junior',
+            'level' => 20,
+            'is_system' => true,
+        ]);
+    }
+
+    public function viewer(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'name' => 'Viewer',
+            'slug' => 'viewer',
+            'level' => 10,
+            'is_system' => true,
+        ]);
+    }
+}

--- a/apps/api/database/factories/TaskFactory.php
+++ b/apps/api/database/factories/TaskFactory.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Task;
+use App\Models\Project;
+use App\Models\TaskStatus;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Task>
+ */
+class TaskFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'project_id' => Project::factory(),
+            'task_status_id' => TaskStatus::factory(),
+            'created_by' => User::factory(),
+            'assigned_to' => fake()->boolean() ? User::factory() : null,
+            'title' => fake()->sentence(4),
+            'description' => fake()->optional()->paragraph(),
+            'priority' => fake()->randomElement(['low', 'medium', 'high', 'urgent']),
+            'due_date' => fake()->optional()->dateTimeBetween('now', '+2 months'),
+        ];
+    }
+
+    public function lowPriority(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'priority' => 'low',
+        ]);
+    }
+
+    public function mediumPriority(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'priority' => 'medium',
+        ]);
+    }
+
+    public function highPriority(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'priority' => 'high',
+        ]);
+    }
+
+    public function urgentPriority(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'priority' => 'urgent',
+        ]);
+    }
+}

--- a/apps/api/database/factories/TaskStatusFactory.php
+++ b/apps/api/database/factories/TaskStatusFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\TaskStatus;
+use App\Models\Project;
+use App\Models\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<TaskStatus>
+ */
+class TaskStatusFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->randomElement(['Backlog', 'Todo', 'In Progress', 'Review', 'Done']).' '.fake()->unique()->numberBetween(1000, 9999);
+
+        return [
+            'workspace_id' => Workspace::factory(),
+            'project_id' => fn (array $attributes) => fake()->boolean()
+                ? Project::factory()->create(['workspace_id' => $attributes['workspace_id']])->id
+                : null,
+            'name' => $name,
+            'slug' => Str::slug($name),
+            'color' => fake()->optional()->hexColor(),
+            'position' => fake()->numberBetween(0, 10),
+            'is_default' => false,
+        ];
+    }
+
+    public function default(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_default' => true,
+            'position' => 0,
+        ]);
+    }
+}

--- a/apps/api/database/factories/TeamFactory.php
+++ b/apps/api/database/factories/TeamFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Team;
+use App\Models\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Team>
+ */
+class TeamFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->unique()->words(2, true);
+
+        return [
+            'workspace_id' => Workspace::factory(),
+            'name' => Str::title($name),
+            'slug' => Str::slug($name).'-'.fake()->unique()->numberBetween(1000, 9999),
+            'description' => fake()->optional()->sentence(),
+        ];
+    }
+}

--- a/apps/api/database/factories/WorkspaceFactory.php
+++ b/apps/api/database/factories/WorkspaceFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Workspace>
+ */
+class WorkspaceFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->unique()->company();
+
+        return [
+            'name' => $name,
+            'slug' => Str::slug($name).'-'.fake()->unique()->numberBetween(1000, 9999),
+            'description' => fake()->optional()->sentence(),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Added model factories for core backend entities.

## Changes

- Added factories for Workspace, Team, Project, Task, Comment, Role, Permission, and TaskStatus
- Added realistic fake values based on the current schema
- Added relationship-aware factory defaults where useful
- Added role and task priority factory states

## Testing

- Created sample records through Laravel Tinker
- Ran `php -l` syntax checks on all factory files
- Reset database with `php artisan migrate:fresh`

## Notes

Seeders and automated tests are intentionally left for later issues.