### PR TITLE
feat: add standard API response format

### DIFF
--- a/apps/api/app/Support/ApiResponse.php
+++ b/apps/api/app/Support/ApiResponse.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Http\JsonResponse;
+
+class ApiResponse
+{
+    public static function success(
+        mixed $data = null,
+        string $message = 'Request successful',
+        int $status = 200
+    ): JsonResponse {
+        return response()->json([
+            'success' => true,
+            'message' => $message,
+            'data' => $data,
+        ], $status);
+    }
+}

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -1,14 +1,11 @@
 <?php
 
+use App\Support\ApiResponse;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/health', function () {
-    return response()->json([
-        'success' => true,
-        'message' => 'API is running',
-        'data' => [
-            'app' => config('app.name'),
-            'environment' => app()->environment(),
-        ],
-    ]);
+    return ApiResponse::success([
+        'app' => config('app.name'),
+        'environment' => app()->environment(),
+    ], 'API is running');
 });


### PR DESCRIPTION
## Summary

Added a reusable standard JSON response format for successful API responses.

## Changes

- Added `App\Support\ApiResponse`
- Added `ApiResponse::success()`
- Updated `/api/health` to use the shared response helper

## Testing

- `docker compose exec api php -l /var/www/html/app/Support/ApiResponse.php`
- `docker compose exec api php artisan optimize:clear`
- `curl http://localhost:8000/api/health`

## Notes

Standard API error formatting is intentionally left for the next issue.