### PR TITLE
feat: add standard API error format

### DIFF
--- a/apps/api/app/Support/ApiResponse.php
+++ b/apps/api/app/Support/ApiResponse.php
@@ -17,4 +17,16 @@ class ApiResponse
             'data' => $data,
         ], $status);
     }
+
+     public static function error(
+        string $message = 'Request failed',
+        array $errors = [],
+        int $status = 400
+    ): JsonResponse {
+        return response()->json([
+            'success' => false,
+            'message' => $message,
+            'errors' => $errors,
+        ], $status);
+    }
 }


### PR DESCRIPTION
## Summary

Added a reusable standard JSON error response format.

## Changes

- Added `ApiResponse::error()`
- Standardized error response shape with `success`, `message`, and `errors`
- Prepared shared structure for validation, authorization, auth, and business-rule errors

## Testing

- `docker compose exec api php -l /var/www/html/app/Support/ApiResponse.php`
- Temporarily tested the error response through `/api/error-test`
- Removed temporary test route after verification
- Confirmed `/api/health` still works

## Notes

Global exception handling and validation exception formatting are intentionally left for later implementation.