### PR TITLE
feat: add authentication routes and controller

### DIFF
--- a/apps/api/app/Http/Controllers/Api/AuthController.php
+++ b/apps/api/app/Http/Controllers/Api/AuthController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class AuthController extends Controller
+{
+    public function register(): JsonResponse
+    {
+        return ApiResponse::success(
+            null,
+            'Registration endpoint is available'
+        );
+    }
+
+    public function login(): JsonResponse
+    {
+        return ApiResponse::success(
+            null,
+            'Login endpoint is available'
+        );
+    }
+
+    public function logout(): JsonResponse
+    {
+        return ApiResponse::success(
+            null,
+            'Logout endpoint is available'
+        );
+    }
+
+    public function me(Request $request): JsonResponse
+    {
+        return ApiResponse::success(
+            [
+                'user' => $request->user(),
+            ],
+            'Authenticated user endpoint is available'
+        );
+    }
+}

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\AuthController;
 use App\Support\ApiResponse;
 use Illuminate\Support\Facades\Route;
 
@@ -8,4 +9,12 @@ Route::get('/health', function () {
         'app' => config('app.name'),
         'environment' => app()->environment(),
     ], 'API is running');
+});
+
+Route::post('/register', [AuthController::class, 'register']);
+Route::post('/login', [AuthController::class, 'login']);
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::post('/logout', [AuthController::class, 'logout']);
+    Route::get('/me', [AuthController::class, 'me']);
 });

--- a/apps/api/tests/Feature/AuthRoutesTest.php
+++ b/apps/api/tests/Feature/AuthRoutesTest.php
@@ -1,0 +1,22 @@
+<?php
+
+it('exposes public auth endpoints', function (string $method, string $uri, string $message) {
+    $this->json($method, $uri)
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => $message,
+            'data' => null,
+        ]);
+})->with([
+    ['POST', '/api/register', 'Registration endpoint is available'],
+    ['POST', '/api/login', 'Login endpoint is available'],
+]);
+
+it('protects authenticated auth endpoints with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['POST', '/api/logout'],
+    ['GET', '/api/me'],
+]);


### PR DESCRIPTION
## Summary

Adds the initial authentication route and controller structure for the Laravel API.

## Changes

- Added `AuthController`
- Added public auth routes:
  - `POST /api/register`
  - `POST /api/login`
- Added protected auth routes:
  - `POST /api/logout`
  - `GET /api/me`
- Protected authenticated routes with `auth:sanctum`
- Preserved the existing `/api/health` route
- Added feature tests for public and protected auth route behavior

## Scope

This PR only creates the auth route/controller structure.

It does not implement:

- Real registration logic
- Real login/logout logic
- Form requests
- Email verification
- Password reset
- Frontend auth pages

## Verification

- `docker compose exec api php artisan route:list`
- `docker compose exec api ./vendor/bin/pest`

All tests passed.