### PR TITLE
feat: add authentication form requests

### DIFF
--- a/apps/api/app/Http/Controllers/Api/AuthController.php
+++ b/apps/api/app/Http/Controllers/Api/AuthController.php
@@ -3,13 +3,15 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\LoginRequest;
+use App\Http\Requests\Auth\RegisterRequest;
 use App\Support\ApiResponse;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class AuthController extends Controller
 {
-    public function register(): JsonResponse
+    public function register(RegisterRequest $request): JsonResponse
     {
         return ApiResponse::success(
             null,
@@ -17,7 +19,7 @@ class AuthController extends Controller
         );
     }
 
-    public function login(): JsonResponse
+    public function login(LoginRequest $request): JsonResponse
     {
         return ApiResponse::success(
             null,

--- a/apps/api/app/Http/Requests/Auth/ForgotPasswordRequest.php
+++ b/apps/api/app/Http/Requests/Auth/ForgotPasswordRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ForgotPasswordRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email'],
+        ];
+    }
+}

--- a/apps/api/app/Http/Requests/Auth/LoginRequest.php
+++ b/apps/api/app/Http/Requests/Auth/LoginRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LoginRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email'],
+            'password' => ['required', 'string'],
+        ];
+    }
+}

--- a/apps/api/app/Http/Requests/Auth/RegisterRequest.php
+++ b/apps/api/app/Http/Requests/Auth/RegisterRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Password;
+
+class RegisterRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'unique:users,email'],
+            'password' => ['required', 'confirmed', Password::defaults()],
+        ];
+    }
+}

--- a/apps/api/app/Http/Requests/Auth/ResetPasswordRequest.php
+++ b/apps/api/app/Http/Requests/Auth/ResetPasswordRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Password;
+
+class ResetPasswordRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'token' => ['required', 'string'],
+            'email' => ['required', 'email'],
+            'password' => ['required', 'confirmed', Password::defaults()],
+        ];
+    }
+}

--- a/apps/api/tests/Feature/AuthRoutesTest.php
+++ b/apps/api/tests/Feature/AuthRoutesTest.php
@@ -1,7 +1,7 @@
 <?php
 
-it('exposes public auth endpoints', function (string $method, string $uri, string $message) {
-    $this->json($method, $uri)
+it('exposes public auth endpoints', function (string $method, string $uri, array $payload, string $message) {
+    $this->json($method, $uri, $payload)
         ->assertOk()
         ->assertJson([
             'success' => true,
@@ -9,9 +9,46 @@ it('exposes public auth endpoints', function (string $method, string $uri, strin
             'data' => null,
         ]);
 })->with([
-    ['POST', '/api/register', 'Registration endpoint is available'],
-    ['POST', '/api/login', 'Login endpoint is available'],
+    [
+        'POST',
+        '/api/register',
+        [
+            'name' => 'Example User',
+            'email' => 'auth-route-register@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ],
+        'Registration endpoint is available',
+    ],
+    [
+        'POST',
+        '/api/login',
+        [
+            'email' => 'auth-route-login@example.com',
+            'password' => 'password',
+        ],
+        'Login endpoint is available',
+    ],
 ]);
+
+it('returns validation errors for invalid registration payloads', function () {
+    $this->postJson('/api/register', [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'name',
+            'email',
+            'password',
+        ]);
+});
+
+it('returns validation errors for invalid login payloads', function () {
+    $this->postJson('/api/login', [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'email',
+            'password',
+        ]);
+});
 
 it('protects authenticated auth endpoints with Sanctum', function (string $method, string $uri) {
     $this->json($method, $uri)


### PR DESCRIPTION
## Summary

Adds dedicated Form Request classes for authentication validation.

## Changes

- Added `RegisterRequest`
- Added `LoginRequest`
- Added `ForgotPasswordRequest`
- Added `ResetPasswordRequest`
- Updated `AuthController` to use request validation for register/login placeholders
- Added validation tests for invalid register and login payloads

## Scope

This PR only adds authentication validation structure.

It does not implement:

- Real registration logic
- Real login/logout behavior
- Email verification behavior
- Password reset behavior
- Frontend auth pages

## Verification

- `docker compose exec api ./vendor/bin/pest`

All tests passed.