### PR TITLE
feat: implement user registration

### DIFF
--- a/apps/api/app/Http/Controllers/Api/AuthController.php
+++ b/apps/api/app/Http/Controllers/Api/AuthController.php
@@ -5,17 +5,36 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\LoginRequest;
 use App\Http\Requests\Auth\RegisterRequest;
+use App\Models\User;
 use App\Support\ApiResponse;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
 
 class AuthController extends Controller
 {
     public function register(RegisterRequest $request): JsonResponse
     {
+        $validated = $request->validated();
+
+        $user = User::create([
+            'name' => $validated['name'],
+            'email' => $validated['email'],
+            'password' => Hash::make($validated['password']),
+        ]);
+
         return ApiResponse::success(
-            null,
-            'Registration endpoint is available'
+            [
+                'user' => [
+                    'id' => $user->id,
+                    'name' => $user->name,
+                    'email' => $user->email,
+                    'created_at' => $user->created_at,
+                    'updated_at' => $user->updated_at,
+                ],
+            ],
+            'User registered successfully',
+            201
         );
     }
 

--- a/apps/api/tests/Feature/AuthRoutesTest.php
+++ b/apps/api/tests/Feature/AuthRoutesTest.php
@@ -1,35 +1,50 @@
 <?php
 
-it('exposes public auth endpoints', function (string $method, string $uri, array $payload, string $message) {
-    $this->json($method, $uri, $payload)
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+
+uses(RefreshDatabase::class);
+
+it('registers a valid user', function () {
+    $response = $this->postJson('/api/register', [
+        'name' => 'Example User',
+        'email' => 'register@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ]);
+
+    $response
+        ->assertCreated()
+        ->assertJson([
+            'success' => true,
+            'message' => 'User registered successfully',
+            'data' => [
+                'user' => [
+                    'name' => 'Example User',
+                    'email' => 'register@example.com',
+                ],
+            ],
+        ]);
+
+    $this->assertDatabaseHas('users', [
+        'name' => 'Example User',
+        'email' => 'register@example.com',
+    ]);
+});
+
+it('exposes the public login endpoint', function () {
+    $this->postJson('/api/login', [
+        'email' => 'auth-route-login@example.com',
+        'password' => 'password',
+    ])
         ->assertOk()
         ->assertJson([
             'success' => true,
-            'message' => $message,
+            'message' => 'Login endpoint is available',
             'data' => null,
         ]);
-})->with([
-    [
-        'POST',
-        '/api/register',
-        [
-            'name' => 'Example User',
-            'email' => 'auth-route-register@example.com',
-            'password' => 'password',
-            'password_confirmation' => 'password',
-        ],
-        'Registration endpoint is available',
-    ],
-    [
-        'POST',
-        '/api/login',
-        [
-            'email' => 'auth-route-login@example.com',
-            'password' => 'password',
-        ],
-        'Login endpoint is available',
-    ],
-]);
+});
 
 it('returns validation errors for invalid registration payloads', function () {
     $this->postJson('/api/register', [])
@@ -39,6 +54,53 @@ it('returns validation errors for invalid registration payloads', function () {
             'email',
             'password',
         ]);
+});
+
+it('rejects duplicate email registration', function () {
+    User::factory()->create([
+        'email' => 'taken@example.com',
+    ]);
+
+    $this->postJson('/api/register', [
+        'name' => 'Duplicate User',
+        'email' => 'taken@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'email',
+        ]);
+});
+
+it('hashes registered user passwords', function () {
+    $this->postJson('/api/register', [
+        'name' => 'Password User',
+        'email' => 'password@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ])->assertCreated();
+
+    $user = User::where('email', 'password@example.com')->firstOrFail();
+
+    expect($user->password)
+        ->not->toBe('password')
+        ->and(Hash::check('password', $user->password))->toBeTrue();
+});
+
+it('does not return sensitive user fields after registration', function () {
+    $response = $this->postJson('/api/register', [
+        'name' => 'Safe User',
+        'email' => 'safe@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ]);
+
+    $response->assertCreated();
+
+    expect($response->json('data.user'))
+        ->not->toHaveKey('password')
+        ->not->toHaveKey('remember_token');
 });
 
 it('returns validation errors for invalid login payloads', function () {


### PR DESCRIPTION
## Summary

Implements API user registration for the Laravel backend.

## Changes

- Implemented real registration logic in `AuthController`
- Creates users from validated registration data
- Hashes passwords using Laravel hashing
- Returns safe user response data only
- Prevents duplicate email registration through validation
- Added registration feature tests

## Test Coverage

Covers:

- Valid user registration
- Invalid registration payloads
- Duplicate email rejection
- Password hashing
- Password and remember token not being returned in the API response

## Scope

This PR only implements user registration.

It does not implement:

- Login behavior
- Logout behavior
- `/api/me` behavior
- Email verification
- Password reset
- Frontend auth pages

## Verification

- `docker compose exec api ./vendor/bin/pest`

All tests passed.