### PR TITLE
feat: implement login logout and current user

### DIFF
--- a/apps/api/app/Http/Controllers/Api/AuthController.php
+++ b/apps/api/app/Http/Controllers/Api/AuthController.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use App\Support\ApiResponse;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 
 class AuthController extends Controller
@@ -25,13 +26,7 @@ class AuthController extends Controller
 
         return ApiResponse::success(
             [
-                'user' => [
-                    'id' => $user->id,
-                    'name' => $user->name,
-                    'email' => $user->email,
-                    'created_at' => $user->created_at,
-                    'updated_at' => $user->updated_at,
-                ],
+                'user' => $this->safeUserData($user),
             ],
             'User registered successfully',
             201
@@ -40,17 +35,44 @@ class AuthController extends Controller
 
     public function login(LoginRequest $request): JsonResponse
     {
+        $credentials = $request->validated();
+
+        if (! Auth::attempt($credentials)) {
+            return ApiResponse::error(
+                'Invalid credentials',
+                [
+                    'email' => ['The provided credentials are incorrect.'],
+                ],
+                401
+            );
+        }
+
+        if ($request->hasSession()) {
+            $request->session()->regenerate();
+        }
+
         return ApiResponse::success(
-            null,
-            'Login endpoint is available'
+            [
+                'user' => $this->safeUserData($request->user()),
+            ],
+            'Logged in successfully'
         );
     }
 
-    public function logout(): JsonResponse
+    public function logout(Request $request): JsonResponse
     {
+        Auth::guard('web')->logout();
+
+        if ($request->hasSession()) {
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+        }
+
+        Auth::forgetGuards();
+
         return ApiResponse::success(
             null,
-            'Logout endpoint is available'
+            'Logged out successfully'
         );
     }
 
@@ -58,9 +80,23 @@ class AuthController extends Controller
     {
         return ApiResponse::success(
             [
-                'user' => $request->user(),
+                'user' => $this->safeUserData($request->user()),
             ],
-            'Authenticated user endpoint is available'
+            'Authenticated user retrieved successfully'
         );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function safeUserData(User $user): array
+    {
+        return [
+            'id' => $user->id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'created_at' => $user->created_at,
+            'updated_at' => $user->updated_at,
+        ];
     }
 }

--- a/apps/api/tests/Feature/AuthRoutesTest.php
+++ b/apps/api/tests/Feature/AuthRoutesTest.php
@@ -33,16 +33,26 @@ it('registers a valid user', function () {
     ]);
 });
 
-it('exposes the public login endpoint', function () {
+it('logs in a valid user', function () {
+    $user = User::factory()->create([
+        'email' => 'login@example.com',
+    ]);
+
     $this->postJson('/api/login', [
-        'email' => 'auth-route-login@example.com',
+        'email' => 'login@example.com',
         'password' => 'password',
     ])
         ->assertOk()
         ->assertJson([
             'success' => true,
-            'message' => 'Login endpoint is available',
-            'data' => null,
+            'message' => 'Logged in successfully',
+            'data' => [
+                'user' => [
+                    'id' => $user->id,
+                    'name' => $user->name,
+                    'email' => 'login@example.com',
+                ],
+            ],
         ]);
 });
 
@@ -103,6 +113,22 @@ it('does not return sensitive user fields after registration', function () {
         ->not->toHaveKey('remember_token');
 });
 
+it('rejects invalid login credentials', function () {
+    User::factory()->create([
+        'email' => 'invalid-login@example.com',
+    ]);
+
+    $this->postJson('/api/login', [
+        'email' => 'invalid-login@example.com',
+        'password' => 'wrong-password',
+    ])
+        ->assertUnauthorized()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Invalid credentials',
+        ]);
+});
+
 it('returns validation errors for invalid login payloads', function () {
     $this->postJson('/api/login', [])
         ->assertUnprocessable()
@@ -112,6 +138,33 @@ it('returns validation errors for invalid login payloads', function () {
         ]);
 });
 
+it('returns the authenticated user from me', function () {
+    $user = User::factory()->create([
+        'email' => 'me@example.com',
+    ]);
+
+    $this->postJson('/api/login', [
+        'email' => 'me@example.com',
+        'password' => 'password',
+    ])->assertOk();
+
+    $this->getJson('/api/me')
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Authenticated user retrieved successfully',
+            'data' => [
+                'user' => [
+                    'id' => $user->id,
+                    'name' => $user->name,
+                    'email' => 'me@example.com',
+                ],
+            ],
+        ])
+        ->assertJsonMissingPath('data.user.password')
+        ->assertJsonMissingPath('data.user.remember_token');
+});
+
 it('protects authenticated auth endpoints with Sanctum', function (string $method, string $uri) {
     $this->json($method, $uri)
         ->assertUnauthorized();
@@ -119,3 +172,39 @@ it('protects authenticated auth endpoints with Sanctum', function (string $metho
     ['POST', '/api/logout'],
     ['GET', '/api/me'],
 ]);
+
+it('logs out an authenticated user', function () {
+    User::factory()->create([
+        'email' => 'logout@example.com',
+    ]);
+
+    $this->postJson('/api/login', [
+        'email' => 'logout@example.com',
+        'password' => 'password',
+    ])->assertOk();
+
+    $this->postJson('/api/logout')
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Logged out successfully',
+            'data' => null,
+        ]);
+});
+
+it('prevents a logged-out user from accessing me', function () {
+    User::factory()->create([
+        'email' => 'logged-out@example.com',
+    ]);
+
+    $this->postJson('/api/login', [
+        'email' => 'logged-out@example.com',
+        'password' => 'password',
+    ])->assertOk();
+
+    $this->getJson('/api/me')->assertOk();
+
+    $this->postJson('/api/logout')->assertOk();
+
+    $this->getJson('/api/me')->assertUnauthorized();
+});


### PR DESCRIPTION
## Summary

Implements core authenticated session behavior for the Laravel API.

## Changes

- Implemented login with email/password authentication
- Added invalid credentials handling
- Regenerated session after successful login
- Implemented logout with session invalidation
- Regenerated CSRF token on logout
- Implemented `/api/me` response with safe authenticated user data
- Reused safe user response formatting for register/login/me
- Added feature tests for login, logout, and current user behavior

## Test Coverage

Covers:

- Valid user login
- Invalid credential rejection
- Authenticated access to `/api/me`
- Unauthenticated protection for `/api/me`
- Authenticated logout
- Logged-out users losing access to protected routes
- Sensitive user fields not returned

## Scope

This PR only implements login, logout, and `/api/me`.

It does not implement:

- Disabled-user handling
- Email verification
- Password reset
- Frontend auth pages

## Verification

- `docker compose exec api ./vendor/bin/pest`

All tests passed.