### PR TITLE
feat: add disabled user auth handling

### DIFF
--- a/apps/api/app/Http/Controllers/Api/AuthController.php
+++ b/apps/api/app/Http/Controllers/Api/AuthController.php
@@ -36,8 +36,9 @@ class AuthController extends Controller
     public function login(LoginRequest $request): JsonResponse
     {
         $credentials = $request->validated();
+        $user = User::where('email', $credentials['email'])->first();
 
-        if (! Auth::attempt($credentials)) {
+        if (! $user || ! Hash::check($credentials['password'], $user->password)) {
             return ApiResponse::error(
                 'Invalid credentials',
                 [
@@ -46,6 +47,18 @@ class AuthController extends Controller
                 401
             );
         }
+
+        if ($user->disabled_at !== null) {
+            return ApiResponse::error(
+                'Account is disabled',
+                [
+                    'account' => ['This account has been disabled.'],
+                ],
+                403
+            );
+        }
+
+        Auth::login($user);
 
         if ($request->hasSession()) {
             $request->session()->regenerate();

--- a/apps/api/app/Http/Middleware/EnsureUserIsNotDisabled.php
+++ b/apps/api/app/Http/Middleware/EnsureUserIsNotDisabled.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Support\ApiResponse;
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureUserIsNotDisabled
+{
+    /**
+     * @param Closure(Request): Response $next
+     */
+    public function handle(Request $request, Closure $next): Response|JsonResponse
+    {
+        $user = $request->user()?->fresh();
+
+        if ($user?->disabled_at !== null) {
+            Auth::guard('web')->logout();
+
+            if ($request->hasSession()) {
+                $request->session()->invalidate();
+                $request->session()->regenerateToken();
+            }
+
+            Auth::forgetGuards();
+
+            return ApiResponse::error(
+                'Account is disabled',
+                [
+                    'account' => ['This account has been disabled.'],
+                ],
+                403
+            );
+        }
+
+        return $next($request);
+    }
+}

--- a/apps/api/app/Models/User.php
+++ b/apps/api/app/Models/User.php
@@ -70,6 +70,7 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
+            'disabled_at' => 'datetime',
             'password' => 'hashed',
         ];
     }

--- a/apps/api/bootstrap/app.php
+++ b/apps/api/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\EnsureUserIsNotDisabled;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -13,6 +14,10 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->statefulApi();
+
+        $middleware->alias([
+            'not.disabled' => EnsureUserIsNotDisabled::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/apps/api/database/migrations/2026_05_04_200000_add_disabled_at_to_users_table.php
+++ b/apps/api/database/migrations/2026_05_04_200000_add_disabled_at_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('disabled_at')->nullable()->after('email_verified_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('disabled_at');
+        });
+    }
+};

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -14,7 +14,7 @@ Route::get('/health', function () {
 Route::post('/register', [AuthController::class, 'register']);
 Route::post('/login', [AuthController::class, 'login']);
 
-Route::middleware('auth:sanctum')->group(function () {
+Route::middleware(['auth:sanctum', 'not.disabled'])->group(function () {
     Route::post('/logout', [AuthController::class, 'logout']);
     Route::get('/me', [AuthController::class, 'me']);
 });

--- a/apps/api/tests/Feature/AuthRoutesTest.php
+++ b/apps/api/tests/Feature/AuthRoutesTest.php
@@ -129,6 +129,26 @@ it('rejects invalid login credentials', function () {
         ]);
 });
 
+it('rejects disabled user login attempts', function () {
+    User::factory()->create([
+        'email' => 'disabled-login@example.com',
+        'disabled_at' => now(),
+    ]);
+
+    $this->postJson('/api/login', [
+        'email' => 'disabled-login@example.com',
+        'password' => 'password',
+    ])
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Account is disabled',
+            'errors' => [
+                'account' => ['This account has been disabled.'],
+            ],
+        ]);
+});
+
 it('returns validation errors for invalid login payloads', function () {
     $this->postJson('/api/login', [])
         ->assertUnprocessable()
@@ -163,6 +183,31 @@ it('returns the authenticated user from me', function () {
         ])
         ->assertJsonMissingPath('data.user.password')
         ->assertJsonMissingPath('data.user.remember_token');
+});
+
+it('blocks disabled authenticated users from me', function () {
+    $user = User::factory()->create([
+        'email' => 'disabled-me@example.com',
+    ]);
+
+    $this->postJson('/api/login', [
+        'email' => 'disabled-me@example.com',
+        'password' => 'password',
+    ])->assertOk();
+
+    $user->forceFill([
+        'disabled_at' => now(),
+    ])->save();
+
+    $this->getJson('/api/me')
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Account is disabled',
+            'errors' => [
+                'account' => ['This account has been disabled.'],
+            ],
+        ]);
 });
 
 it('protects authenticated auth endpoints with Sanctum', function (string $method, string $uri) {
@@ -207,4 +252,29 @@ it('prevents a logged-out user from accessing me', function () {
     $this->postJson('/api/logout')->assertOk();
 
     $this->getJson('/api/me')->assertUnauthorized();
+});
+
+it('blocks disabled authenticated users from logout', function () {
+    $user = User::factory()->create([
+        'email' => 'disabled-logout@example.com',
+    ]);
+
+    $this->postJson('/api/login', [
+        'email' => 'disabled-logout@example.com',
+        'password' => 'password',
+    ])->assertOk();
+
+    $user->forceFill([
+        'disabled_at' => now(),
+    ])->save();
+
+    $this->postJson('/api/logout')
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Account is disabled',
+            'errors' => [
+                'account' => ['This account has been disabled.'],
+            ],
+        ]);
 });


### PR DESCRIPTION
## Summary

Adds backend authentication handling for disabled user accounts.

## Changes

- Added nullable `disabled_at` column to users
- Added `disabled_at` datetime cast on the `User` model
- Blocked disabled users from logging in
- Added middleware to block already-authenticated disabled users from protected auth routes
- Applied disabled-user middleware to protected auth endpoints
- Added disabled-user authentication tests

## Test Coverage

Covers:

- Active users can log in
- Disabled users cannot log in
- Disabled authenticated users cannot access `/api/me`
- Disabled authenticated users cannot access `/api/logout`
- Disabled-account responses return a clear API error

## Scope

This PR only implements backend disabled-user authentication handling.

It does not implement:

- Admin user management
- User enable/disable UI
- Email verification
- Password reset
- Frontend auth pages

## Verification

- `docker compose exec api php artisan migrate:fresh --seed`
- `docker compose exec api ./vendor/bin/pest`

All verification commands passed.