### PR TITLE
feat: add email verification support

### DIFF
--- a/apps/api/app/Http/Controllers/Api/AuthController.php
+++ b/apps/api/app/Http/Controllers/Api/AuthController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\Auth\LoginRequest;
 use App\Http\Requests\Auth\RegisterRequest;
 use App\Models\User;
 use App\Support\ApiResponse;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -23,6 +24,10 @@ class AuthController extends Controller
             'email' => $validated['email'],
             'password' => Hash::make($validated['password']),
         ]);
+
+        if ($user instanceof MustVerifyEmail) {
+            $user->sendEmailVerificationNotification();
+        }
 
         return ApiResponse::success(
             [

--- a/apps/api/app/Http/Controllers/Api/EmailVerificationController.php
+++ b/apps/api/app/Http/Controllers/Api/EmailVerificationController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\Support\ApiResponse;
+use Illuminate\Auth\Events\Verified;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class EmailVerificationController extends Controller
+{
+    public function verify(Request $request, string $id, string $hash): JsonResponse
+    {
+        $user = User::find($id);
+
+        if (! $request->hasValidSignature() || ! $user || ! hash_equals(sha1($user->getEmailForVerification()), $hash)) {
+            return ApiResponse::error(
+                'Invalid verification link',
+                [
+                    'verification' => ['The email verification link is invalid or has expired.'],
+                ],
+                403
+            );
+        }
+
+        if ($user->hasVerifiedEmail()) {
+            return ApiResponse::success(
+                null,
+                'Email is already verified'
+            );
+        }
+
+        $user->markEmailAsVerified();
+
+        event(new Verified($user));
+
+        return ApiResponse::success(
+            null,
+            'Email verified successfully'
+        );
+    }
+
+    public function resend(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        if ($user->hasVerifiedEmail()) {
+            return ApiResponse::success(
+                null,
+                'Email is already verified'
+            );
+        }
+
+        $user->sendEmailVerificationNotification();
+
+        return ApiResponse::success(
+            null,
+            'Verification email sent'
+        );
+    }
+}

--- a/apps/api/app/Models/User.php
+++ b/apps/api/app/Models/User.php
@@ -2,8 +2,8 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Database\Factories\UserFactory;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -13,7 +13,7 @@ use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 
 #[Hidden(['password', 'remember_token'])]
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<UserFactory> */
     use HasApiTokens, HasFactory, Notifiable;

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\AuthController;
+use App\Http\Controllers\Api\EmailVerificationController;
 use App\Support\ApiResponse;
 use Illuminate\Support\Facades\Route;
 
@@ -13,8 +14,11 @@ Route::get('/health', function () {
 
 Route::post('/register', [AuthController::class, 'register']);
 Route::post('/login', [AuthController::class, 'login']);
+Route::get('/verify-email/{id}/{hash}', [EmailVerificationController::class, 'verify'])
+    ->name('verification.verify');
 
 Route::middleware(['auth:sanctum', 'not.disabled'])->group(function () {
     Route::post('/logout', [AuthController::class, 'logout']);
     Route::get('/me', [AuthController::class, 'me']);
+    Route::post('/email/verification-notification', [EmailVerificationController::class, 'resend']);
 });

--- a/apps/api/tests/Feature/AuthRoutesTest.php
+++ b/apps/api/tests/Feature/AuthRoutesTest.php
@@ -1,8 +1,11 @@
 <?php
 
 use App\Models\User;
+use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\URL;
 
 uses(RefreshDatabase::class);
 
@@ -31,6 +34,23 @@ it('registers a valid user', function () {
         'name' => 'Example User',
         'email' => 'register@example.com',
     ]);
+});
+
+it('sends a verification email to newly registered users', function () {
+    Notification::fake();
+
+    $this->postJson('/api/register', [
+        'name' => 'Verify User',
+        'email' => 'verify-register@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ])->assertCreated();
+
+    $user = User::where('email', 'verify-register@example.com')->firstOrFail();
+
+    expect($user->hasVerifiedEmail())->toBeFalse();
+
+    Notification::assertSentTo($user, VerifyEmail::class);
 });
 
 it('logs in a valid user', function () {
@@ -185,6 +205,73 @@ it('returns the authenticated user from me', function () {
         ->assertJsonMissingPath('data.user.remember_token');
 });
 
+it('allows an authenticated unverified user to request verification resend', function () {
+    Notification::fake();
+
+    User::factory()->unverified()->create([
+        'email' => 'resend@example.com',
+    ]);
+
+    $this->postJson('/api/login', [
+        'email' => 'resend@example.com',
+        'password' => 'password',
+    ])->assertOk();
+
+    $this->postJson('/api/email/verification-notification')
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Verification email sent',
+            'data' => null,
+        ]);
+
+    $user = User::where('email', 'resend@example.com')->firstOrFail();
+
+    Notification::assertSentTo($user, VerifyEmail::class);
+});
+
+it('marks a user email as verified from a valid verification link', function () {
+    $user = User::factory()->unverified()->create();
+
+    $this->getJson(signedVerificationUrlFor($user))
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Email verified successfully',
+            'data' => null,
+        ]);
+
+    expect($user->fresh()->hasVerifiedEmail())->toBeTrue();
+});
+
+it('rejects invalid verification links', function () {
+    $user = User::factory()->unverified()->create();
+
+    $this->getJson(signedVerificationUrlFor($user, sha1('invalid-email')))
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Invalid verification link',
+            'errors' => [
+                'verification' => ['The email verification link is invalid or has expired.'],
+            ],
+        ]);
+
+    expect($user->fresh()->hasVerifiedEmail())->toBeFalse();
+});
+
+it('returns an appropriate response when email is already verified', function () {
+    $user = User::factory()->create();
+
+    $this->getJson(signedVerificationUrlFor($user))
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Email is already verified',
+            'data' => null,
+        ]);
+});
+
 it('blocks disabled authenticated users from me', function () {
     $user = User::factory()->create([
         'email' => 'disabled-me@example.com',
@@ -217,6 +304,11 @@ it('protects authenticated auth endpoints with Sanctum', function (string $metho
     ['POST', '/api/logout'],
     ['GET', '/api/me'],
 ]);
+
+it('prevents unauthenticated users from requesting verification resend', function () {
+    $this->postJson('/api/email/verification-notification')
+        ->assertUnauthorized();
+});
 
 it('logs out an authenticated user', function () {
     User::factory()->create([
@@ -278,3 +370,15 @@ it('blocks disabled authenticated users from logout', function () {
             ],
         ]);
 });
+
+function signedVerificationUrlFor(User $user, ?string $hash = null): string
+{
+    return URL::temporarySignedRoute(
+        'verification.verify',
+        now()->addMinutes(60),
+        [
+            'id' => $user->id,
+            'hash' => $hash ?? sha1($user->getEmailForVerification()),
+        ]
+    );
+}


### PR DESCRIPTION
## Summary

Adds backend email verification support for API authentication.

## Changes

- Enabled Laravel email verification on the `User` model
- Sent verification emails after registration
- Added email verification controller
- Added signed verification endpoint
- Added verification resend endpoint
- Protected verification resend behind authenticated API middleware
- Added email verification feature tests

## Test Coverage

Covers:

- Newly registered users receive verification emails
- Authenticated unverified users can request verification resend
- Valid verification links mark users as verified
- Invalid verification links are rejected
- Already verified users receive an appropriate response
- Unauthenticated users cannot request verification resend

## Scope

This PR only implements backend email verification support.

It does not implement:

- Password reset
- Frontend verification pages
- Admin user management
- Documentation updates

## Verification

- `docker compose exec api php artisan migrate:fresh --seed`
- `docker compose exec api ./vendor/bin/pest`

All verification commands passed.