### PR TITLE
feat: add password reset support

### DIFF
--- a/apps/api/app/Http/Controllers/Api/PasswordResetController.php
+++ b/apps/api/app/Http/Controllers/Api/PasswordResetController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\ForgotPasswordRequest;
+use App\Http\Requests\Auth\ResetPasswordRequest;
+use App\Models\User;
+use App\Support\ApiResponse;
+use Illuminate\Auth\Events\PasswordReset;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Str;
+
+class PasswordResetController extends Controller
+{
+    public function forgotPassword(ForgotPasswordRequest $request): JsonResponse
+    {
+        $status = Password::sendResetLink($request->validated());
+
+        if ($status !== Password::RESET_LINK_SENT) {
+            return ApiResponse::error(
+                'Unable to send password reset link',
+                [
+                    'email' => [__($status)],
+                ],
+                422
+            );
+        }
+
+        return ApiResponse::success(
+            null,
+            'Password reset link sent'
+        );
+    }
+
+    public function resetPassword(ResetPasswordRequest $request): JsonResponse
+    {
+        $status = Password::reset(
+            $request->validated(),
+            function (User $user, string $password): void {
+                $user->forceFill([
+                    'password' => Hash::make($password),
+                ])->setRememberToken(Str::random(60));
+
+                $user->save();
+
+                event(new PasswordReset($user));
+            }
+        );
+
+        if ($status !== Password::PASSWORD_RESET) {
+            return ApiResponse::error(
+                'Invalid password reset token',
+                [
+                    'token' => [__($status)],
+                ],
+                422
+            );
+        }
+
+        return ApiResponse::success(
+            null,
+            'Password reset successfully'
+        );
+    }
+}

--- a/apps/api/app/Providers/AppServiceProvider.php
+++ b/apps/api/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +20,11 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        ResetPassword::createUrlUsing(function (object $notifiable, string $token): string {
+            return url('/reset-password?'.http_build_query([
+                'token' => $token,
+                'email' => $notifiable->getEmailForPasswordReset(),
+            ]));
+        });
     }
 }

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\EmailVerificationController;
+use App\Http\Controllers\Api\PasswordResetController;
 use App\Support\ApiResponse;
 use Illuminate\Support\Facades\Route;
 
@@ -14,6 +15,8 @@ Route::get('/health', function () {
 
 Route::post('/register', [AuthController::class, 'register']);
 Route::post('/login', [AuthController::class, 'login']);
+Route::post('/forgot-password', [PasswordResetController::class, 'forgotPassword']);
+Route::post('/reset-password', [PasswordResetController::class, 'resetPassword']);
 Route::get('/verify-email/{id}/{hash}', [EmailVerificationController::class, 'verify'])
     ->name('verification.verify');
 

--- a/apps/api/tests/Feature/AuthRoutesTest.php
+++ b/apps/api/tests/Feature/AuthRoutesTest.php
@@ -1,10 +1,12 @@
 <?php
 
 use App\Models\User;
+use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Facades\URL;
 
 uses(RefreshDatabase::class);
@@ -173,6 +175,110 @@ it('returns validation errors for invalid login payloads', function () {
     $this->postJson('/api/login', [])
         ->assertUnprocessable()
         ->assertJsonValidationErrors([
+            'email',
+            'password',
+        ]);
+});
+
+it('sends a password reset email when requested', function () {
+    Notification::fake();
+
+    $user = User::factory()->create([
+        'email' => 'forgot-password@example.com',
+    ]);
+
+    $this->postJson('/api/forgot-password', [
+        'email' => 'forgot-password@example.com',
+    ])
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Password reset link sent',
+            'data' => null,
+        ]);
+
+    Notification::assertSentTo($user, ResetPassword::class);
+});
+
+it('resets a password with a valid token', function () {
+    $user = User::factory()->create([
+        'email' => 'reset-password@example.com',
+    ]);
+
+    $token = Password::broker()->createToken($user);
+
+    $this->postJson('/api/reset-password', [
+        'token' => $token,
+        'email' => 'reset-password@example.com',
+        'password' => 'new-password',
+        'password_confirmation' => 'new-password',
+    ])
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Password reset successfully',
+            'data' => null,
+        ]);
+
+    expect(Hash::check('new-password', $user->fresh()->password))->toBeTrue();
+});
+
+it('rejects invalid password reset tokens', function () {
+    User::factory()->create([
+        'email' => 'invalid-reset-token@example.com',
+    ]);
+
+    $this->postJson('/api/reset-password', [
+        'token' => 'invalid-token',
+        'email' => 'invalid-reset-token@example.com',
+        'password' => 'new-password',
+        'password_confirmation' => 'new-password',
+    ])
+        ->assertUnprocessable()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Invalid password reset token',
+        ]);
+});
+
+it('logs in with the new password after reset', function () {
+    $user = User::factory()->create([
+        'email' => 'login-after-reset@example.com',
+    ]);
+
+    $token = Password::broker()->createToken($user);
+
+    $this->postJson('/api/reset-password', [
+        'token' => $token,
+        'email' => 'login-after-reset@example.com',
+        'password' => 'new-password',
+        'password_confirmation' => 'new-password',
+    ])->assertOk();
+
+    $this->postJson('/api/login', [
+        'email' => 'login-after-reset@example.com',
+        'password' => 'new-password',
+    ])
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Logged in successfully',
+        ]);
+});
+
+it('returns validation errors for invalid forgot password payloads', function () {
+    $this->postJson('/api/forgot-password', [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'email',
+        ]);
+});
+
+it('returns validation errors for invalid reset password payloads', function () {
+    $this->postJson('/api/reset-password', [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'token',
             'email',
             'password',
         ]);


### PR DESCRIPTION
## Summary

Adds backend forgot-password and reset-password API support.

## Changes

- Added `PasswordResetController`
- Added `POST /api/forgot-password`
- Added `POST /api/reset-password`
- Sends password reset notifications through Laravel's password broker
- Resets passwords using valid reset tokens
- Hashes new passwords securely
- Customizes reset email URL generation for the API-only backend
- Added password reset feature tests

## Test Coverage

Covers:

- Users can request password reset emails
- Password reset notifications are sent
- Valid reset tokens update passwords
- Invalid reset tokens are rejected
- Users can log in with the new password after reset
- Forgot-password validation errors
- Reset-password validation errors

## Scope

This PR only implements backend password reset support.

It does not implement:

- Frontend password reset pages
- Admin user management
- Documentation updates

## Verification

- `docker compose exec api php artisan migrate:fresh --seed`
- `docker compose exec api ./vendor/bin/pest`

All verification commands passed.