### PR TITLE
docs: document phase 2 authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The project is built as a full-stack portfolio application focused on:
 - Laravel
 - PHP
 - MySQL
-- Laravel Sanctum planned for authentication
+- Laravel Sanctum for authentication
 - Pest / PHPUnit
 
 ### Frontend
@@ -160,6 +160,26 @@ junior@demo.test
 viewer@demo.test
 ```
 
+## Authentication
+
+Phase 2 backend authentication is implemented with Laravel Sanctum session authentication.
+
+Implemented API auth includes registration, login, logout, `GET /api/me`, disabled-user handling, email verification, password reset, and auth feature tests.
+
+SPA clients should call the Sanctum CSRF endpoint before state-changing authenticated requests:
+
+```txt
+GET /sanctum/csrf-cookie
+```
+
+Local auth emails can be inspected in Mailpit:
+
+```txt
+http://localhost:8025
+```
+
+For endpoint details and behavior notes, see `docs/auth.md`.
+
 ## Docker Services
 
 The local Docker environment includes:
@@ -200,6 +220,7 @@ See:
 
 ```txt
 docs/architecture.md
+docs/auth.md
 docs/database.md
 docs/testing.md
 docs/setup.md
@@ -210,20 +231,22 @@ docs/ai-rules.md
 
 ## Current Status
 
-Phase 1: Backend foundation completed.
+Phase 1 backend foundation and Phase 2 backend authentication are complete.
 
 Implemented:
 
 - Laravel API route foundation with `GET /api/health`
 - Shared API response helper
+- Laravel Sanctum session authentication
+- Registration, login, logout, current user, email verification, password reset, and disabled-user auth handling
 - Core Eloquent models and relationships
 - Database migrations for users, workspaces, teams, projects, tasks, comments, roles, permissions, statuses, and pivots
 - Factories and seeders for backend smoke data
-- Pest smoke tests for health, database factories, and seeders
+- Pest tests for health, database factories, seeders, and auth behavior
 
 Planned later:
 
-- Authentication
-- Controllers and request validation
+- Frontend auth pages
+- Team/project/task CRUD
 - Policies and backend permission enforcement
 - Frontend application workflows

--- a/docs/ai-rules.md
+++ b/docs/ai-rules.md
@@ -42,6 +42,30 @@ Use Policies for authorization.
 
 Use Services or Actions for business logic.
 
+## Authentication Rules
+
+Backend auth is implemented with Laravel Sanctum cookie/session authentication.
+
+When changing auth behavior, update focused tests in:
+
+```txt
+apps/api/tests/Feature/AuthRoutesTest.php
+```
+
+Auth changes must preserve:
+
+- `App\Support\ApiResponse` JSON response shape
+- Form Request validation
+- Server-side protected route enforcement
+- Disabled-user blocking through `users.disabled_at`
+- Safe user responses without passwords or remember tokens
+
+Detailed auth behavior is documented in:
+
+```txt
+docs/auth.md
+```
+
 ## Permission Rules
 
 Never rely on frontend-only permissions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@
 
 ScaffoldIX is a full-stack project management application for small software teams.
 
-The repository is intentionally documentation-heavy because the project is being built in phases. This file separates the implemented Phase 1 backend foundation from planned later architecture.
+The repository is intentionally documentation-heavy because the project is being built in phases. This file separates implemented backend foundation and auth work from planned later architecture.
 
 ## Monorepo Structure
 
@@ -25,14 +25,16 @@ scaffoldix/
 
 Laravel backend API.
 
-Phase 1 responsibilities already present:
+Implemented backend responsibilities:
 
 - API route bootstrap
 - `GET /api/health`
 - Shared API response helper
+- Sanctum-backed registration, login, logout, current-user, email verification, and password reset endpoints
+- Disabled-user auth blocking through `users.disabled_at`
 - Eloquent models and relationships
 - Migrations, factories, and seeders
-- Pest smoke tests
+- Pest smoke and auth feature tests
 
 ### apps/web
 
@@ -53,17 +55,27 @@ Important rule:
 
 Frontend permissions are for user experience only. Real permission enforcement must happen on the Laravel backend.
 
-## Implemented Phase 1 Backend
+## Implemented Backend
 
 ### API Route Foundation
 
-The backend currently exposes a minimal API route in `apps/api/routes/api.php`:
+The backend exposes API routes in `apps/api/routes/api.php`.
 
 ```txt
 GET /api/health
+POST /api/register
+POST /api/login
+POST /api/logout
+GET /api/me
+GET /api/verify-email/{id}/{hash}
+POST /api/email/verification-notification
+POST /api/forgot-password
+POST /api/reset-password
 ```
 
 The health route returns a standardized success response with the app name and current environment.
+
+Auth endpoint details are documented in `docs/auth.md`.
 
 ### API Responses
 
@@ -119,32 +131,33 @@ The backend includes seeders for:
 
 ### Tests
 
-Pest is installed for backend testing. Phase 1 smoke tests cover:
+Pest is installed for backend testing. Current backend tests cover:
 
 - Health endpoint response shape
 - `User` and `Workspace` factory persistence
 - Database seeder demo data
+- Auth feature behavior
 
 See `docs/testing.md` for test commands and current coverage.
 
 ## Not Implemented Yet
 
-The following backend pieces are planned but not implemented in Phase 1:
+The following pieces are planned but not implemented yet:
 
-- Authentication flows
-- Laravel Sanctum setup for login/logout workflows
 - Controllers for domain resources
-- Form request validation
 - API resources
 - Policies and gates
 - Permission service
 - Role hierarchy service
 - Business workflow endpoints
+- Frontend auth pages
+- Admin dashboard
+- Production deployment
 - Frontend dashboard workflows
 
 ## Frontend Architecture
 
-The frontend architecture below is planned. It is not the active Phase 1 focus yet.
+The frontend architecture below is planned. Backend auth is implemented, but frontend auth pages and dashboard workflows are not built yet.
 
 Preferred structure:
 
@@ -220,9 +233,11 @@ Planned later entities may include sprints, activity logs, attachments, invitati
 
 ## Authentication
 
-Authentication is planned and is not implemented yet.
+Backend authentication is implemented with Laravel Sanctum session auth.
 
-The intended approach is Laravel Sanctum with the frontend as a first-party SPA-style client.
+Implemented auth includes registration, login, logout, current user, disabled-user handling, email verification, password reset, and tests.
+
+See `docs/auth.md` for endpoint details, CSRF notes, Mailpit usage, and out-of-scope items.
 
 Current local development URLs:
 
@@ -257,16 +272,16 @@ Implemented now:
 
 1. Backend smoke tests
 2. Seeder smoke tests
+3. Auth feature tests
 
 Planned testing priority:
 
-1. Auth tests
-2. Permission tests
-3. Policy tests
-4. Controller and API workflow tests
-5. Task workflow tests
-6. Frontend smoke tests
-7. Browser/E2E tests
+1. Permission tests
+2. Policy tests
+3. Controller and API workflow tests
+4. Task workflow tests
+5. Frontend smoke tests
+6. Browser/E2E tests
 
 ## Deployment Direction
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,128 @@
+# Authentication
+
+## Overview
+
+Phase 2 backend authentication is implemented in the Laravel API using Laravel Sanctum session authentication.
+
+Implemented auth features:
+
+- User registration
+- Login and logout
+- Current authenticated user endpoint
+- Disabled-user blocking with `users.disabled_at`
+- Email verification
+- Password reset
+- Auth feature tests
+
+Frontend auth pages are not implemented yet.
+
+## Endpoints
+
+| Method | Path | Auth | Purpose |
+| --- | --- | --- | --- |
+| `POST` | `/api/register` | Public | Register a user and send email verification. |
+| `POST` | `/api/login` | Public | Log in with email and password. |
+| `POST` | `/api/logout` | Authenticated | Log out and invalidate the session. |
+| `GET` | `/api/me` | Authenticated | Return safe current-user data. |
+| `GET` | `/api/verify-email/{id}/{hash}` | Signed link | Verify a user's email address. |
+| `POST` | `/api/email/verification-notification` | Authenticated | Resend email verification notification. |
+| `POST` | `/api/forgot-password` | Public | Send password reset email. |
+| `POST` | `/api/reset-password` | Public | Reset password with a valid token. |
+
+Sanctum also exposes:
+
+```txt
+GET /sanctum/csrf-cookie
+```
+
+SPA clients should call the CSRF cookie endpoint before making state-changing authenticated requests.
+
+## Session Auth
+
+The API uses Sanctum's cookie/session-based SPA authentication flow.
+
+Local development uses:
+
+```txt
+Frontend: http://localhost:3000
+Backend:  http://localhost:8000
+```
+
+The Docker API service configures Sanctum stateful domains for localhost development. Frontend permission checks are only for user experience; backend routes remain the enforcement point.
+
+## Disabled Users
+
+Disabled users are represented by nullable `users.disabled_at`.
+
+Behavior:
+
+- Disabled users cannot log in.
+- Already-authenticated users who become disabled are blocked from protected auth routes.
+- Disabled authenticated users are logged out when blocked.
+
+## Email Verification
+
+The `User` model uses Laravel's standard `MustVerifyEmail` support.
+
+Behavior:
+
+- Registration sends a verification email.
+- Verification links are signed Laravel URLs.
+- Valid verification links mark `email_verified_at`.
+- Authenticated unverified users can request another verification email.
+
+Local emails are captured by Mailpit:
+
+```txt
+http://localhost:8025
+```
+
+## Password Reset
+
+Password reset uses Laravel's standard password broker and `password_reset_tokens` table.
+
+Behavior:
+
+- Users can request a password reset email.
+- Valid reset tokens update the stored password.
+- New passwords are hashed by Laravel.
+- Invalid reset tokens are rejected.
+
+## Demo Users
+
+Seeded demo users use the password `password`:
+
+```txt
+admin@demo.test
+teamlead@demo.test
+senior@demo.test
+mid@demo.test
+junior@demo.test
+viewer@demo.test
+```
+
+## Tests
+
+Run backend tests from the repository root:
+
+```bash
+docker compose exec api ./vendor/bin/pest
+```
+
+Auth coverage lives in:
+
+```txt
+apps/api/tests/Feature/AuthRoutesTest.php
+```
+
+Covered areas include registration, login, logout, `/api/me`, protected-route rejection, disabled-user handling, email verification, password reset, validation errors, and sensitive-field exclusions.
+
+## Out Of Scope
+
+Phase 2 auth does not include:
+
+- Frontend auth pages
+- Team/project/task CRUD
+- Permission policies
+- Admin dashboard
+- Production deployment

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -78,3 +78,31 @@ After the API container is running:
 ```bash
 curl http://localhost:8000/api/health
 ```
+
+## Authentication Setup Notes
+
+Backend authentication uses Laravel Sanctum cookie/session auth.
+
+For SPA-style local requests, call the CSRF cookie endpoint before state-changing authenticated requests:
+
+```txt
+GET http://localhost:8000/sanctum/csrf-cookie
+```
+
+Auth endpoint details are documented in `docs/auth.md`.
+
+## Mailpit
+
+The Docker API service sends local auth emails through Mailpit:
+
+```txt
+MAIL_MAILER=smtp
+MAIL_HOST=mailpit
+MAIL_PORT=1025
+```
+
+Inspect verification and password reset emails in the browser:
+
+```txt
+http://localhost:8025
+```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,27 +12,32 @@ docker compose exec api ./vendor/bin/pest
 
 Laravel and Composer commands should be run inside the `api` container so they use the container PHP extensions and the `api_vendor` volume.
 
-## Existing Smoke Tests
+## Existing Tests
 
-Phase 1 includes small backend smoke tests:
+The backend includes smoke tests and focused auth feature tests:
 
 | Test file | What it verifies |
 | --- | --- |
 | `HealthEndpointTest` | `GET /api/health` returns HTTP 200 and the expected JSON success shape. |
 | `DatabaseSmokeTest` | `User::factory()->create()` and `Workspace::factory()->create()` persist records. |
 | `SeederSmokeTest` | `DatabaseSeeder` creates demo users, demo workspace, demo project, and `admin.access`. |
+| `AuthRoutesTest` | Registration, login, logout, current user, protected routes, disabled users, email verification, password reset, validation errors, and sensitive-field exclusions. |
 
-These tests are intended to confirm that the backend foundation boots, migrations run, factories persist data, and seeders produce the expected demo baseline.
+These tests confirm that the backend foundation boots, migrations run, factories persist data, seeders produce the expected demo baseline, and auth behavior works.
+
+Run only auth tests:
+
+```bash
+docker compose exec api ./vendor/bin/pest tests/Feature/AuthRoutesTest.php
+```
 
 ## Not Tested Yet
 
-The Phase 1 smoke tests intentionally do not test:
+The current backend tests intentionally do not test:
 
-- Auth
 - Permissions
 - Policies
 - Controllers
-- Request validation
 - Business workflows
 - Frontend behavior
 


### PR DESCRIPTION
## Summary

Documents the completed Phase 2 backend authentication foundation.

## Changes

- Added `docs/auth.md`
- Updated README authentication/status sections
- Updated architecture documentation to reflect implemented backend auth
- Added Sanctum and auth rules to AI guidance
- Added local auth and Mailpit setup notes
- Updated testing documentation with auth test coverage

## Documented Auth Areas

- Sanctum session authentication
- Auth endpoints
- CSRF cookie endpoint
- Registration
- Login/logout
- Current user endpoint
- Disabled-user behavior
- Email verification
- Password reset
- Demo user credentials
- Mailpit usage
- Auth test commands
- Phase 2 out-of-scope items

## Scope

This PR is documentation-only.

It does not modify:

- Application code
- Tests
- Migrations
- Composer files
- Docker configuration

## Verification

Not run. Documentation-only change.