### PR TITLE
feat: add core domain API foundation

### DIFF
--- a/apps/api/app/Http/Controllers/Api/CommentController.php
+++ b/apps/api/app/Http/Controllers/Api/CommentController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreCommentRequest;
+use App\Http\Requests\Domain\UpdateCommentRequest;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+
+class CommentController extends Controller
+{
+    public function index(string $task): JsonResponse
+    {
+        return $this->placeholder('Comment index endpoint is not implemented yet');
+    }
+
+    public function store(StoreCommentRequest $request, string $task): JsonResponse
+    {
+        return $this->placeholder('Comment store endpoint is not implemented yet');
+    }
+
+    public function show(string $task, string $comment): JsonResponse
+    {
+        return $this->placeholder('Comment show endpoint is not implemented yet');
+    }
+
+    public function update(UpdateCommentRequest $request, string $task, string $comment): JsonResponse
+    {
+        return $this->placeholder('Comment update endpoint is not implemented yet');
+    }
+
+    public function destroy(string $task, string $comment): JsonResponse
+    {
+        return $this->placeholder('Comment destroy endpoint is not implemented yet');
+    }
+
+    private function placeholder(string $message): JsonResponse
+    {
+        return ApiResponse::error($message, [], 501);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/ProjectController.php
+++ b/apps/api/app/Http/Controllers/Api/ProjectController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreProjectRequest;
+use App\Http\Requests\Domain\UpdateProjectRequest;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+
+class ProjectController extends Controller
+{
+    public function index(string $workspace): JsonResponse
+    {
+        return $this->placeholder('Project index endpoint is not implemented yet');
+    }
+
+    public function store(StoreProjectRequest $request, string $workspace): JsonResponse
+    {
+        return $this->placeholder('Project store endpoint is not implemented yet');
+    }
+
+    public function show(string $workspace, string $project): JsonResponse
+    {
+        return $this->placeholder('Project show endpoint is not implemented yet');
+    }
+
+    public function update(UpdateProjectRequest $request, string $workspace, string $project): JsonResponse
+    {
+        return $this->placeholder('Project update endpoint is not implemented yet');
+    }
+
+    public function destroy(string $workspace, string $project): JsonResponse
+    {
+        return $this->placeholder('Project destroy endpoint is not implemented yet');
+    }
+
+    private function placeholder(string $message): JsonResponse
+    {
+        return ApiResponse::error($message, [], 501);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/TaskController.php
+++ b/apps/api/app/Http/Controllers/Api/TaskController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreTaskRequest;
+use App\Http\Requests\Domain\UpdateTaskRequest;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+
+class TaskController extends Controller
+{
+    public function index(string $project): JsonResponse
+    {
+        return $this->placeholder('Task index endpoint is not implemented yet');
+    }
+
+    public function store(StoreTaskRequest $request, string $project): JsonResponse
+    {
+        return $this->placeholder('Task store endpoint is not implemented yet');
+    }
+
+    public function show(string $project, string $task): JsonResponse
+    {
+        return $this->placeholder('Task show endpoint is not implemented yet');
+    }
+
+    public function update(UpdateTaskRequest $request, string $project, string $task): JsonResponse
+    {
+        return $this->placeholder('Task update endpoint is not implemented yet');
+    }
+
+    public function destroy(string $project, string $task): JsonResponse
+    {
+        return $this->placeholder('Task destroy endpoint is not implemented yet');
+    }
+
+    private function placeholder(string $message): JsonResponse
+    {
+        return ApiResponse::error($message, [], 501);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/TaskStatusController.php
+++ b/apps/api/app/Http/Controllers/Api/TaskStatusController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreTaskStatusRequest;
+use App\Http\Requests\Domain\UpdateTaskStatusRequest;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+
+class TaskStatusController extends Controller
+{
+    public function index(string $project): JsonResponse
+    {
+        return $this->placeholder('Task status index endpoint is not implemented yet');
+    }
+
+    public function store(StoreTaskStatusRequest $request, string $project): JsonResponse
+    {
+        return $this->placeholder('Task status store endpoint is not implemented yet');
+    }
+
+    public function show(string $project, string $taskStatus): JsonResponse
+    {
+        return $this->placeholder('Task status show endpoint is not implemented yet');
+    }
+
+    public function update(UpdateTaskStatusRequest $request, string $project, string $taskStatus): JsonResponse
+    {
+        return $this->placeholder('Task status update endpoint is not implemented yet');
+    }
+
+    public function destroy(string $project, string $taskStatus): JsonResponse
+    {
+        return $this->placeholder('Task status destroy endpoint is not implemented yet');
+    }
+
+    private function placeholder(string $message): JsonResponse
+    {
+        return ApiResponse::error($message, [], 501);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/TeamController.php
+++ b/apps/api/app/Http/Controllers/Api/TeamController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreTeamRequest;
+use App\Http\Requests\Domain\UpdateTeamRequest;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+
+class TeamController extends Controller
+{
+    public function index(string $workspace): JsonResponse
+    {
+        return $this->placeholder('Team index endpoint is not implemented yet');
+    }
+
+    public function store(StoreTeamRequest $request, string $workspace): JsonResponse
+    {
+        return $this->placeholder('Team store endpoint is not implemented yet');
+    }
+
+    public function show(string $workspace, string $team): JsonResponse
+    {
+        return $this->placeholder('Team show endpoint is not implemented yet');
+    }
+
+    public function update(UpdateTeamRequest $request, string $workspace, string $team): JsonResponse
+    {
+        return $this->placeholder('Team update endpoint is not implemented yet');
+    }
+
+    public function destroy(string $workspace, string $team): JsonResponse
+    {
+        return $this->placeholder('Team destroy endpoint is not implemented yet');
+    }
+
+    private function placeholder(string $message): JsonResponse
+    {
+        return ApiResponse::error($message, [], 501);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/WorkspaceController.php
+++ b/apps/api/app/Http/Controllers/Api/WorkspaceController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreWorkspaceRequest;
+use App\Http\Requests\Domain\UpdateWorkspaceRequest;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+
+class WorkspaceController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return $this->placeholder('Workspace index endpoint is not implemented yet');
+    }
+
+    public function store(StoreWorkspaceRequest $request): JsonResponse
+    {
+        return $this->placeholder('Workspace store endpoint is not implemented yet');
+    }
+
+    public function show(string $workspace): JsonResponse
+    {
+        return $this->placeholder('Workspace show endpoint is not implemented yet');
+    }
+
+    public function update(UpdateWorkspaceRequest $request, string $workspace): JsonResponse
+    {
+        return $this->placeholder('Workspace update endpoint is not implemented yet');
+    }
+
+    public function destroy(string $workspace): JsonResponse
+    {
+        return $this->placeholder('Workspace destroy endpoint is not implemented yet');
+    }
+
+    private function placeholder(string $message): JsonResponse
+    {
+        return ApiResponse::error($message, [], 501);
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreCommentRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreCommentRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCommentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreProjectRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreProjectRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreProjectRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreTaskRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreTaskRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTaskRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreTaskStatusRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreTaskStatusRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTaskStatusRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreTeamRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreTeamRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTeamRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreWorkspaceRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreWorkspaceRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreWorkspaceRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/UpdateCommentRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateCommentRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCommentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/UpdateProjectRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateProjectRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateProjectRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/UpdateTaskRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateTaskRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateTaskRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/UpdateTaskStatusRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateTaskStatusRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateTaskStatusRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/UpdateTeamRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateTeamRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateTeamRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/UpdateWorkspaceRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateWorkspaceRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateWorkspaceRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Resources/CommentResource.php
+++ b/apps/api/app/Http/Resources/CommentResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CommentResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'task_id' => $this->task_id,
+            'user_id' => $this->user_id,
+            'body' => $this->body,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/ProjectResource.php
+++ b/apps/api/app/Http/Resources/ProjectResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ProjectResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'workspace_id' => $this->workspace_id,
+            'team_id' => $this->team_id,
+            'created_by' => $this->created_by,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'description' => $this->description,
+            'starts_at' => $this->starts_at,
+            'ends_at' => $this->ends_at,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/TaskResource.php
+++ b/apps/api/app/Http/Resources/TaskResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TaskResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'project_id' => $this->project_id,
+            'task_status_id' => $this->task_status_id,
+            'created_by' => $this->created_by,
+            'assigned_to' => $this->assigned_to,
+            'title' => $this->title,
+            'description' => $this->description,
+            'priority' => $this->priority,
+            'due_date' => $this->due_date,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/TaskStatusResource.php
+++ b/apps/api/app/Http/Resources/TaskStatusResource.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TaskStatusResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'workspace_id' => $this->workspace_id,
+            'project_id' => $this->project_id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'color' => $this->color,
+            'position' => $this->position,
+            'is_default' => $this->is_default,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/TeamResource.php
+++ b/apps/api/app/Http/Resources/TeamResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TeamResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'workspace_id' => $this->workspace_id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'description' => $this->description,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/WorkspaceResource.php
+++ b/apps/api/app/Http/Resources/WorkspaceResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class WorkspaceResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'description' => $this->description,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -1,8 +1,14 @@
 <?php
 
 use App\Http\Controllers\Api\AuthController;
+use App\Http\Controllers\Api\CommentController;
 use App\Http\Controllers\Api\EmailVerificationController;
 use App\Http\Controllers\Api\PasswordResetController;
+use App\Http\Controllers\Api\ProjectController;
+use App\Http\Controllers\Api\TaskController;
+use App\Http\Controllers\Api\TaskStatusController;
+use App\Http\Controllers\Api\TeamController;
+use App\Http\Controllers\Api\WorkspaceController;
 use App\Support\ApiResponse;
 use Illuminate\Support\Facades\Route;
 
@@ -24,4 +30,12 @@ Route::middleware(['auth:sanctum', 'not.disabled'])->group(function () {
     Route::post('/logout', [AuthController::class, 'logout']);
     Route::get('/me', [AuthController::class, 'me']);
     Route::post('/email/verification-notification', [EmailVerificationController::class, 'resend']);
+
+    Route::apiResource('workspaces', WorkspaceController::class);
+    Route::apiResource('workspaces.teams', TeamController::class);
+    Route::apiResource('workspaces.projects', ProjectController::class);
+    Route::apiResource('projects.task-statuses', TaskStatusController::class)
+        ->parameters(['task-statuses' => 'taskStatus']);
+    Route::apiResource('projects.tasks', TaskController::class);
+    Route::apiResource('tasks.comments', CommentController::class);
 });

--- a/apps/api/tests/Feature/DomainRoutesTest.php
+++ b/apps/api/tests/Feature/DomainRoutesTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects domain routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/workspaces'],
+    ['POST', '/api/workspaces'],
+    ['GET', '/api/workspaces/1/teams'],
+    ['GET', '/api/workspaces/1/projects'],
+    ['GET', '/api/projects/1/task-statuses'],
+    ['GET', '/api/projects/1/tasks'],
+    ['GET', '/api/tasks/1/comments'],
+]);
+
+it('blocks disabled authenticated users from domain routes', function () {
+    $user = User::factory()->create([
+        'email' => 'disabled-domain@example.com',
+    ]);
+
+    $this->postJson('/api/login', [
+        'email' => 'disabled-domain@example.com',
+        'password' => 'password',
+    ])->assertOk();
+
+    $user->forceFill([
+        'disabled_at' => now(),
+    ])->save();
+
+    $this->getJson('/api/workspaces')
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Account is disabled',
+            'errors' => [
+                'account' => ['This account has been disabled.'],
+            ],
+        ]);
+});


### PR DESCRIPTION
## Summary

- Added Phase 3 domain API controller skeletons.
- Added initial domain Form Request classes.
- Added API Resource classes for core domain models.
- Registered protected REST-style domain routes.
- Added route protection tests for domain endpoints.

## What changed

Created backend API structure for workspaces, teams, projects, task statuses, tasks, and comments.

Domain routes are registered inside the existing authenticated middleware group using `auth:sanctum` and `not.disabled`.

Controller methods are intentionally placeholders and return HTTP 501 API error responses until CRUD behavior is implemented in later issues.

## Testing

- `docker compose exec api php artisan route:list`
- `docker compose exec api ./vendor/bin/pest`

Latest confirmed result:

- 45 tests passed
- 125 assertions

## Notes

- No CRUD behavior was implemented.
- No frontend work was added.
- No role/permission matrix logic was implemented.
- Full domain authorization rules remain for later Phase 3 issues and Phase 4 permissions.