### PR TITLE
feat: implement team membership endpoints

### DIFF
--- a/apps/api/app/Http/Controllers/Api/TeamMemberController.php
+++ b/apps/api/app/Http/Controllers/Api/TeamMemberController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreTeamMemberRequest;
+use App\Http\Resources\UserResource;
+use App\Models\Team;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class TeamMemberController extends Controller
+{
+    public function index(Request $request, string $workspace, string $team): JsonResponse
+    {
+        $team = $this->accessibleTeam($request, $workspace, $team);
+
+        if (! $team) {
+            return $this->forbidden();
+        }
+
+        $members = $team->users()
+            ->orderBy('name')
+            ->get();
+
+        return ApiResponse::success(
+            UserResource::collection($members),
+            'Team members retrieved successfully'
+        );
+    }
+
+    public function store(StoreTeamMemberRequest $request, string $workspace, string $team): JsonResponse
+    {
+        $team = $this->accessibleTeam($request, $workspace, $team);
+
+        if (! $team) {
+            return $this->forbidden();
+        }
+
+        $team->users()->attach($request->validated('user_id'));
+
+        $member = $team->users()
+            ->whereKey($request->validated('user_id'))
+            ->firstOrFail();
+
+        return ApiResponse::success(
+            new UserResource($member),
+            'Team member added successfully',
+            201
+        );
+    }
+
+    public function destroy(Request $request, string $workspace, string $team, string $user): JsonResponse
+    {
+        $team = $this->accessibleTeam($request, $workspace, $team);
+
+        if (! $team) {
+            return $this->forbidden();
+        }
+
+        $team->users()->detach($user);
+
+        return ApiResponse::success(
+            null,
+            'Team member removed successfully'
+        );
+    }
+
+    private function accessibleTeam(Request $request, string $workspace, string $team): ?Team
+    {
+        return Team::query()
+            ->whereKey($team)
+            ->where('workspace_id', $workspace)
+            ->whereHas('workspace.teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function forbidden(): JsonResponse
+    {
+        return ApiResponse::error(
+            'Team access denied',
+            [
+                'team' => ['You do not have access to this team.'],
+            ],
+            403
+        );
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreTeamMemberRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreTeamMemberRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreTeamMemberRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $teamId = $this->route('team');
+
+        return [
+            'user_id' => [
+                'required',
+                'integer',
+                Rule::exists('users', 'id'),
+                Rule::unique('team_user', 'user_id')
+                    ->where(fn ($query) => $query->where('team_id', $teamId)),
+            ],
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/UserResource.php
+++ b/apps/api/app/Http/Resources/UserResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class UserResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+            'created_at' => $this->created_at,
+        ];
+    }
+}

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Api\ProjectController;
 use App\Http\Controllers\Api\TaskController;
 use App\Http\Controllers\Api\TaskStatusController;
 use App\Http\Controllers\Api\TeamController;
+use App\Http\Controllers\Api\TeamMemberController;
 use App\Http\Controllers\Api\WorkspaceController;
 use App\Support\ApiResponse;
 use Illuminate\Support\Facades\Route;
@@ -32,6 +33,9 @@ Route::middleware(['auth:sanctum', 'not.disabled'])->group(function () {
     Route::post('/email/verification-notification', [EmailVerificationController::class, 'resend']);
 
     Route::apiResource('workspaces', WorkspaceController::class);
+    Route::get('/workspaces/{workspace}/teams/{team}/members', [TeamMemberController::class, 'index']);
+    Route::post('/workspaces/{workspace}/teams/{team}/members', [TeamMemberController::class, 'store']);
+    Route::delete('/workspaces/{workspace}/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy']);
     Route::apiResource('workspaces.teams', TeamController::class);
     Route::apiResource('workspaces.projects', ProjectController::class);
     Route::apiResource('projects.task-statuses', TaskStatusController::class)

--- a/apps/api/tests/Feature/TeamMemberRoutesTest.php
+++ b/apps/api/tests/Feature/TeamMemberRoutesTest.php
@@ -1,0 +1,251 @@
+<?php
+
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects team member routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/workspaces/1/teams/1/members'],
+    ['POST', '/api/workspaces/1/teams/1/members'],
+    ['DELETE', '/api/workspaces/1/teams/1/members/1'],
+]);
+
+it('lists team members for an accessible team', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-list-manager@example.com',
+        'name' => 'Manager User',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'team-member-list-member@example.com',
+        'name' => 'Member User',
+    ]);
+    [$workspace, $team] = teamMemberEndpointTeamForUser($manager);
+
+    $team->users()->attach($member->id);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->getJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Team members retrieved successfully',
+        ])
+        ->assertJsonFragment([
+            'id' => $manager->id,
+            'name' => 'Manager User',
+            'email' => 'team-member-list-manager@example.com',
+        ])
+        ->assertJsonFragment([
+            'id' => $member->id,
+            'name' => 'Member User',
+            'email' => 'team-member-list-member@example.com',
+        ]);
+});
+
+it('adds a member to an accessible team', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-add-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'team-member-add-member@example.com',
+        'name' => 'Added Member',
+    ]);
+    [$workspace, $team] = teamMemberEndpointTeamForUser($manager);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertCreated()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Team member added successfully',
+            'data' => [
+                'id' => $member->id,
+                'name' => 'Added Member',
+                'email' => 'team-member-add-member@example.com',
+            ],
+        ]);
+
+    $this->assertDatabaseHas('team_user', [
+        'team_id' => $team->id,
+        'user_id' => $member->id,
+    ]);
+});
+
+it('returns validation errors when adding an invalid team member', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-validation@example.com',
+    ]);
+    [$workspace, $team] = teamMemberEndpointTeamForUser($manager);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members", [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'user_id',
+        ]);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members", [
+        'user_id' => 999999,
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'user_id',
+        ]);
+});
+
+it('rejects duplicate team membership', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-duplicate-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'team-member-duplicate-member@example.com',
+    ]);
+    [$workspace, $team] = teamMemberEndpointTeamForUser($manager);
+
+    $team->users()->attach($member->id);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'user_id',
+        ]);
+});
+
+it('removes a member from an accessible team', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-remove-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'team-member-remove-member@example.com',
+    ]);
+    [$workspace, $team] = teamMemberEndpointTeamForUser($manager);
+
+    $team->users()->attach($member->id);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->deleteJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members/{$member->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Team member removed successfully',
+            'data' => null,
+        ]);
+
+    $this->assertDatabaseMissing('team_user', [
+        'team_id' => $team->id,
+        'user_id' => $member->id,
+    ]);
+});
+
+it('forbids inaccessible team membership management', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-forbidden-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'team-member-forbidden-member@example.com',
+    ]);
+    [$accessibleWorkspace] = teamMemberEndpointTeamForUser($manager);
+    $hiddenWorkspace = Workspace::factory()->create();
+    $hiddenTeam = Team::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+    ]);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->getJson("/api/workspaces/{$hiddenWorkspace->id}/teams/{$hiddenTeam->id}/members")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+            'errors' => [
+                'team' => ['You do not have access to this team.'],
+            ],
+        ]);
+
+    $this->postJson("/api/workspaces/{$accessibleWorkspace->id}/teams/{$hiddenTeam->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+        ]);
+
+    $this->deleteJson("/api/workspaces/{$accessibleWorkspace->id}/teams/{$hiddenTeam->id}/members/{$member->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+        ]);
+});
+
+it('does not expose sensitive user fields in member responses', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-safe-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'team-member-safe-member@example.com',
+    ]);
+    [$workspace, $team] = teamMemberEndpointTeamForUser($manager);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertCreated()
+        ->assertJsonMissingPath('data.password')
+        ->assertJsonMissingPath('data.remember_token')
+        ->assertJsonMissingPath('data.email_verified_at')
+        ->assertJsonMissingPath('data.disabled_at')
+        ->assertJsonMissingPath('data.roles')
+        ->assertJsonMissingPath('data.permissions');
+
+    $this->getJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members")
+        ->assertOk()
+        ->assertJsonMissingPath('data.0.password')
+        ->assertJsonMissingPath('data.0.remember_token')
+        ->assertJsonMissingPath('data.0.email_verified_at')
+        ->assertJsonMissingPath('data.0.disabled_at')
+        ->assertJsonMissingPath('data.0.roles')
+        ->assertJsonMissingPath('data.0.permissions');
+});
+
+function teamMemberEndpointLoginAs(User $user): void
+{
+    test()->postJson('/api/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertOk();
+}
+
+/**
+ * @return array{Workspace, Team}
+ */
+function teamMemberEndpointTeamForUser(User $user): array
+{
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+
+    $team->users()->attach($user->id);
+
+    return [$workspace, $team];
+}


### PR DESCRIPTION
## Summary

- Added authenticated team membership endpoints.
- Added team member listing, adding, and removing behavior.
- Added team member validation.
- Added safe user serialization through `UserResource`.
- Added team membership feature tests.

## What changed

Team membership can now be managed through protected API routes under workspace teams.

Membership management is scoped to accessible teams only. Duplicate team membership is rejected through validation, and responses expose only safe user fields.

## Testing

- `docker compose exec api php artisan route:list`
- `docker compose exec api ./vendor/bin/pest`

Latest confirmed result:

- 85 tests passed
- 277 assertions

## Notes

- No frontend work was added.
- No team roles were assigned.
- No `team_user_role` behavior was added.
- No Phase 4 permission matrix logic was implemented.