### PR TITLE
Feature/project membership endpoints

### DIFF
--- a/apps/api/app/Http/Controllers/Api/CommentController.php
+++ b/apps/api/app/Http/Controllers/Api/CommentController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreCommentRequest;
+use App\Http\Requests\Domain\UpdateCommentRequest;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+
+class CommentController extends Controller
+{
+    public function index(string $task): JsonResponse
+    {
+        return $this->placeholder('Comment index endpoint is not implemented yet');
+    }
+
+    public function store(StoreCommentRequest $request, string $task): JsonResponse
+    {
+        return $this->placeholder('Comment store endpoint is not implemented yet');
+    }
+
+    public function show(string $task, string $comment): JsonResponse
+    {
+        return $this->placeholder('Comment show endpoint is not implemented yet');
+    }
+
+    public function update(UpdateCommentRequest $request, string $task, string $comment): JsonResponse
+    {
+        return $this->placeholder('Comment update endpoint is not implemented yet');
+    }
+
+    public function destroy(string $task, string $comment): JsonResponse
+    {
+        return $this->placeholder('Comment destroy endpoint is not implemented yet');
+    }
+
+    private function placeholder(string $message): JsonResponse
+    {
+        return ApiResponse::error($message, [], 501);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/ProjectController.php
+++ b/apps/api/app/Http/Controllers/Api/ProjectController.php
@@ -5,38 +5,128 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Domain\StoreProjectRequest;
 use App\Http\Requests\Domain\UpdateProjectRequest;
+use App\Http\Resources\ProjectResource;
+use App\Models\Project;
+use App\Models\Workspace;
 use App\Support\ApiResponse;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 class ProjectController extends Controller
 {
-    public function index(string $workspace): JsonResponse
+    public function index(Request $request, string $workspace): JsonResponse
     {
-        return $this->placeholder('Project index endpoint is not implemented yet');
+        $workspace = $this->accessibleWorkspace($request, $workspace);
+
+        if (! $workspace) {
+            return $this->forbidden();
+        }
+
+        $projects = $workspace->projects()
+            ->orderBy('name')
+            ->get();
+
+        return ApiResponse::success(
+            ProjectResource::collection($projects),
+            'Projects retrieved successfully'
+        );
     }
 
     public function store(StoreProjectRequest $request, string $workspace): JsonResponse
     {
-        return $this->placeholder('Project store endpoint is not implemented yet');
+        $workspace = $this->accessibleWorkspace($request, $workspace);
+
+        if (! $workspace) {
+            return $this->forbidden();
+        }
+
+        $project = $workspace->projects()->create([
+            ...$request->validated(),
+            'created_by' => $request->user()->id,
+        ]);
+
+        return ApiResponse::success(
+            new ProjectResource($project),
+            'Project created successfully',
+            201
+        );
     }
 
-    public function show(string $workspace, string $project): JsonResponse
+    public function show(Request $request, string $workspace, string $project): JsonResponse
     {
-        return $this->placeholder('Project show endpoint is not implemented yet');
+        $project = $this->accessibleProject($request, $workspace, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        return ApiResponse::success(
+            new ProjectResource($project),
+            'Project retrieved successfully'
+        );
     }
 
     public function update(UpdateProjectRequest $request, string $workspace, string $project): JsonResponse
     {
-        return $this->placeholder('Project update endpoint is not implemented yet');
+        $project = $this->accessibleProject($request, $workspace, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $project->update($request->validated());
+
+        return ApiResponse::success(
+            new ProjectResource($project),
+            'Project updated successfully'
+        );
     }
 
-    public function destroy(string $workspace, string $project): JsonResponse
+    public function destroy(Request $request, string $workspace, string $project): JsonResponse
     {
-        return $this->placeholder('Project destroy endpoint is not implemented yet');
+        $project = $this->accessibleProject($request, $workspace, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $project->delete();
+
+        return ApiResponse::success(
+            null,
+            'Project deleted successfully'
+        );
     }
 
-    private function placeholder(string $message): JsonResponse
+    private function accessibleWorkspace(Request $request, string $workspace): ?Workspace
     {
-        return ApiResponse::error($message, [], 501);
+        return Workspace::query()
+            ->whereKey($workspace)
+            ->whereHas('teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function accessibleProject(Request $request, string $workspace, string $project): ?Project
+    {
+        return Project::query()
+            ->whereKey($project)
+            ->where('workspace_id', $workspace)
+            ->whereHas('workspace.teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function forbidden(): JsonResponse
+    {
+        return ApiResponse::error(
+            'Project access denied',
+            [
+                'project' => ['You do not have access to this project.'],
+            ],
+            403
+        );
     }
 }

--- a/apps/api/app/Http/Controllers/Api/ProjectController.php
+++ b/apps/api/app/Http/Controllers/Api/ProjectController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreProjectRequest;
+use App\Http\Requests\Domain\UpdateProjectRequest;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+
+class ProjectController extends Controller
+{
+    public function index(string $workspace): JsonResponse
+    {
+        return $this->placeholder('Project index endpoint is not implemented yet');
+    }
+
+    public function store(StoreProjectRequest $request, string $workspace): JsonResponse
+    {
+        return $this->placeholder('Project store endpoint is not implemented yet');
+    }
+
+    public function show(string $workspace, string $project): JsonResponse
+    {
+        return $this->placeholder('Project show endpoint is not implemented yet');
+    }
+
+    public function update(UpdateProjectRequest $request, string $workspace, string $project): JsonResponse
+    {
+        return $this->placeholder('Project update endpoint is not implemented yet');
+    }
+
+    public function destroy(string $workspace, string $project): JsonResponse
+    {
+        return $this->placeholder('Project destroy endpoint is not implemented yet');
+    }
+
+    private function placeholder(string $message): JsonResponse
+    {
+        return ApiResponse::error($message, [], 501);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/ProjectMemberController.php
+++ b/apps/api/app/Http/Controllers/Api/ProjectMemberController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreProjectMemberRequest;
+use App\Http\Resources\UserResource;
+use App\Models\Project;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ProjectMemberController extends Controller
+{
+    public function index(Request $request, string $workspace, string $project): JsonResponse
+    {
+        $project = $this->accessibleProject($request, $workspace, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $members = $project->users()
+            ->orderBy('name')
+            ->get();
+
+        return ApiResponse::success(
+            UserResource::collection($members),
+            'Project members retrieved successfully'
+        );
+    }
+
+    public function store(StoreProjectMemberRequest $request, string $workspace, string $project): JsonResponse
+    {
+        $project = $this->accessibleProject($request, $workspace, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $project->users()->attach($request->validated('user_id'));
+
+        $member = $project->users()
+            ->whereKey($request->validated('user_id'))
+            ->firstOrFail();
+
+        return ApiResponse::success(
+            new UserResource($member),
+            'Project member added successfully',
+            201
+        );
+    }
+
+    public function destroy(Request $request, string $workspace, string $project, string $user): JsonResponse
+    {
+        $project = $this->accessibleProject($request, $workspace, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $project->users()->detach($user);
+
+        return ApiResponse::success(
+            null,
+            'Project member removed successfully'
+        );
+    }
+
+    private function accessibleProject(Request $request, string $workspace, string $project): ?Project
+    {
+        return Project::query()
+            ->whereKey($project)
+            ->where('workspace_id', $workspace)
+            ->whereHas('workspace.teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function forbidden(): JsonResponse
+    {
+        return ApiResponse::error(
+            'Project access denied',
+            [
+                'project' => ['You do not have access to this project.'],
+            ],
+            403
+        );
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/TaskController.php
+++ b/apps/api/app/Http/Controllers/Api/TaskController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreTaskRequest;
+use App\Http\Requests\Domain\UpdateTaskRequest;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+
+class TaskController extends Controller
+{
+    public function index(string $project): JsonResponse
+    {
+        return $this->placeholder('Task index endpoint is not implemented yet');
+    }
+
+    public function store(StoreTaskRequest $request, string $project): JsonResponse
+    {
+        return $this->placeholder('Task store endpoint is not implemented yet');
+    }
+
+    public function show(string $project, string $task): JsonResponse
+    {
+        return $this->placeholder('Task show endpoint is not implemented yet');
+    }
+
+    public function update(UpdateTaskRequest $request, string $project, string $task): JsonResponse
+    {
+        return $this->placeholder('Task update endpoint is not implemented yet');
+    }
+
+    public function destroy(string $project, string $task): JsonResponse
+    {
+        return $this->placeholder('Task destroy endpoint is not implemented yet');
+    }
+
+    private function placeholder(string $message): JsonResponse
+    {
+        return ApiResponse::error($message, [], 501);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/TaskStatusController.php
+++ b/apps/api/app/Http/Controllers/Api/TaskStatusController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreTaskStatusRequest;
+use App\Http\Requests\Domain\UpdateTaskStatusRequest;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+
+class TaskStatusController extends Controller
+{
+    public function index(string $project): JsonResponse
+    {
+        return $this->placeholder('Task status index endpoint is not implemented yet');
+    }
+
+    public function store(StoreTaskStatusRequest $request, string $project): JsonResponse
+    {
+        return $this->placeholder('Task status store endpoint is not implemented yet');
+    }
+
+    public function show(string $project, string $taskStatus): JsonResponse
+    {
+        return $this->placeholder('Task status show endpoint is not implemented yet');
+    }
+
+    public function update(UpdateTaskStatusRequest $request, string $project, string $taskStatus): JsonResponse
+    {
+        return $this->placeholder('Task status update endpoint is not implemented yet');
+    }
+
+    public function destroy(string $project, string $taskStatus): JsonResponse
+    {
+        return $this->placeholder('Task status destroy endpoint is not implemented yet');
+    }
+
+    private function placeholder(string $message): JsonResponse
+    {
+        return ApiResponse::error($message, [], 501);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/TeamController.php
+++ b/apps/api/app/Http/Controllers/Api/TeamController.php
@@ -5,38 +5,125 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Domain\StoreTeamRequest;
 use App\Http\Requests\Domain\UpdateTeamRequest;
+use App\Http\Resources\TeamResource;
+use App\Models\Team;
+use App\Models\Workspace;
 use App\Support\ApiResponse;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 class TeamController extends Controller
 {
-    public function index(string $workspace): JsonResponse
+    public function index(Request $request, string $workspace): JsonResponse
     {
-        return $this->placeholder('Team index endpoint is not implemented yet');
+        $workspace = $this->accessibleWorkspace($request, $workspace);
+
+        if (! $workspace) {
+            return $this->forbidden();
+        }
+
+        $teams = $workspace->teams()
+            ->orderBy('name')
+            ->get();
+
+        return ApiResponse::success(
+            TeamResource::collection($teams),
+            'Teams retrieved successfully'
+        );
     }
 
     public function store(StoreTeamRequest $request, string $workspace): JsonResponse
     {
-        return $this->placeholder('Team store endpoint is not implemented yet');
+        $workspace = $this->accessibleWorkspace($request, $workspace);
+
+        if (! $workspace) {
+            return $this->forbidden();
+        }
+
+        $team = $workspace->teams()->create($request->validated());
+
+        return ApiResponse::success(
+            new TeamResource($team),
+            'Team created successfully',
+            201
+        );
     }
 
-    public function show(string $workspace, string $team): JsonResponse
+    public function show(Request $request, string $workspace, string $team): JsonResponse
     {
-        return $this->placeholder('Team show endpoint is not implemented yet');
+        $team = $this->accessibleTeam($request, $workspace, $team);
+
+        if (! $team) {
+            return $this->forbidden();
+        }
+
+        return ApiResponse::success(
+            new TeamResource($team),
+            'Team retrieved successfully'
+        );
     }
 
     public function update(UpdateTeamRequest $request, string $workspace, string $team): JsonResponse
     {
-        return $this->placeholder('Team update endpoint is not implemented yet');
+        $team = $this->accessibleTeam($request, $workspace, $team);
+
+        if (! $team) {
+            return $this->forbidden();
+        }
+
+        $team->update($request->validated());
+
+        return ApiResponse::success(
+            new TeamResource($team),
+            'Team updated successfully'
+        );
     }
 
-    public function destroy(string $workspace, string $team): JsonResponse
+    public function destroy(Request $request, string $workspace, string $team): JsonResponse
     {
-        return $this->placeholder('Team destroy endpoint is not implemented yet');
+        $team = $this->accessibleTeam($request, $workspace, $team);
+
+        if (! $team) {
+            return $this->forbidden();
+        }
+
+        $team->delete();
+
+        return ApiResponse::success(
+            null,
+            'Team deleted successfully'
+        );
     }
 
-    private function placeholder(string $message): JsonResponse
+    private function accessibleWorkspace(Request $request, string $workspace): ?Workspace
     {
-        return ApiResponse::error($message, [], 501);
+        return Workspace::query()
+            ->whereKey($workspace)
+            ->whereHas('teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function accessibleTeam(Request $request, string $workspace, string $team): ?Team
+    {
+        return Team::query()
+            ->whereKey($team)
+            ->where('workspace_id', $workspace)
+            ->whereHas('workspace.teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function forbidden(): JsonResponse
+    {
+        return ApiResponse::error(
+            'Team access denied',
+            [
+                'team' => ['You do not have access to this team.'],
+            ],
+            403
+        );
     }
 }

--- a/apps/api/app/Http/Controllers/Api/TeamController.php
+++ b/apps/api/app/Http/Controllers/Api/TeamController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreTeamRequest;
+use App\Http\Requests\Domain\UpdateTeamRequest;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+
+class TeamController extends Controller
+{
+    public function index(string $workspace): JsonResponse
+    {
+        return $this->placeholder('Team index endpoint is not implemented yet');
+    }
+
+    public function store(StoreTeamRequest $request, string $workspace): JsonResponse
+    {
+        return $this->placeholder('Team store endpoint is not implemented yet');
+    }
+
+    public function show(string $workspace, string $team): JsonResponse
+    {
+        return $this->placeholder('Team show endpoint is not implemented yet');
+    }
+
+    public function update(UpdateTeamRequest $request, string $workspace, string $team): JsonResponse
+    {
+        return $this->placeholder('Team update endpoint is not implemented yet');
+    }
+
+    public function destroy(string $workspace, string $team): JsonResponse
+    {
+        return $this->placeholder('Team destroy endpoint is not implemented yet');
+    }
+
+    private function placeholder(string $message): JsonResponse
+    {
+        return ApiResponse::error($message, [], 501);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/TeamMemberController.php
+++ b/apps/api/app/Http/Controllers/Api/TeamMemberController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreTeamMemberRequest;
+use App\Http\Resources\UserResource;
+use App\Models\Team;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class TeamMemberController extends Controller
+{
+    public function index(Request $request, string $workspace, string $team): JsonResponse
+    {
+        $team = $this->accessibleTeam($request, $workspace, $team);
+
+        if (! $team) {
+            return $this->forbidden();
+        }
+
+        $members = $team->users()
+            ->orderBy('name')
+            ->get();
+
+        return ApiResponse::success(
+            UserResource::collection($members),
+            'Team members retrieved successfully'
+        );
+    }
+
+    public function store(StoreTeamMemberRequest $request, string $workspace, string $team): JsonResponse
+    {
+        $team = $this->accessibleTeam($request, $workspace, $team);
+
+        if (! $team) {
+            return $this->forbidden();
+        }
+
+        $team->users()->attach($request->validated('user_id'));
+
+        $member = $team->users()
+            ->whereKey($request->validated('user_id'))
+            ->firstOrFail();
+
+        return ApiResponse::success(
+            new UserResource($member),
+            'Team member added successfully',
+            201
+        );
+    }
+
+    public function destroy(Request $request, string $workspace, string $team, string $user): JsonResponse
+    {
+        $team = $this->accessibleTeam($request, $workspace, $team);
+
+        if (! $team) {
+            return $this->forbidden();
+        }
+
+        $team->users()->detach($user);
+
+        return ApiResponse::success(
+            null,
+            'Team member removed successfully'
+        );
+    }
+
+    private function accessibleTeam(Request $request, string $workspace, string $team): ?Team
+    {
+        return Team::query()
+            ->whereKey($team)
+            ->where('workspace_id', $workspace)
+            ->whereHas('workspace.teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function forbidden(): JsonResponse
+    {
+        return ApiResponse::error(
+            'Team access denied',
+            [
+                'team' => ['You do not have access to this team.'],
+            ],
+            403
+        );
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/WorkspaceController.php
+++ b/apps/api/app/Http/Controllers/Api/WorkspaceController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreWorkspaceRequest;
+use App\Http\Requests\Domain\UpdateWorkspaceRequest;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+
+class WorkspaceController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return $this->placeholder('Workspace index endpoint is not implemented yet');
+    }
+
+    public function store(StoreWorkspaceRequest $request): JsonResponse
+    {
+        return $this->placeholder('Workspace store endpoint is not implemented yet');
+    }
+
+    public function show(string $workspace): JsonResponse
+    {
+        return $this->placeholder('Workspace show endpoint is not implemented yet');
+    }
+
+    public function update(UpdateWorkspaceRequest $request, string $workspace): JsonResponse
+    {
+        return $this->placeholder('Workspace update endpoint is not implemented yet');
+    }
+
+    public function destroy(string $workspace): JsonResponse
+    {
+        return $this->placeholder('Workspace destroy endpoint is not implemented yet');
+    }
+
+    private function placeholder(string $message): JsonResponse
+    {
+        return ApiResponse::error($message, [], 501);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/WorkspaceController.php
+++ b/apps/api/app/Http/Controllers/Api/WorkspaceController.php
@@ -5,38 +5,117 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Domain\StoreWorkspaceRequest;
 use App\Http\Requests\Domain\UpdateWorkspaceRequest;
+use App\Http\Resources\WorkspaceResource;
+use App\Models\Workspace;
 use App\Support\ApiResponse;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class WorkspaceController extends Controller
 {
-    public function index(): JsonResponse
+    public function index(Request $request): JsonResponse
     {
-        return $this->placeholder('Workspace index endpoint is not implemented yet');
+        $workspaces = Workspace::query()
+            ->whereHas('teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->orderBy('name')
+            ->get();
+
+        return ApiResponse::success(
+            WorkspaceResource::collection($workspaces),
+            'Workspaces retrieved successfully'
+        );
     }
 
     public function store(StoreWorkspaceRequest $request): JsonResponse
     {
-        return $this->placeholder('Workspace store endpoint is not implemented yet');
+        $workspace = DB::transaction(function () use ($request): Workspace {
+            $workspace = Workspace::create($request->validated());
+
+            $team = $workspace->teams()->create([
+                'name' => 'Default Team',
+                'slug' => 'default-team',
+                'description' => 'Default team for workspace members.',
+            ]);
+
+            $team->users()->attach($request->user()->id);
+
+            return $workspace;
+        });
+
+        return ApiResponse::success(
+            new WorkspaceResource($workspace),
+            'Workspace created successfully',
+            201
+        );
     }
 
-    public function show(string $workspace): JsonResponse
+    public function show(Request $request, string $workspace): JsonResponse
     {
-        return $this->placeholder('Workspace show endpoint is not implemented yet');
+        $workspace = $this->accessibleWorkspace($request, $workspace);
+
+        if (! $workspace) {
+            return $this->forbidden();
+        }
+
+        return ApiResponse::success(
+            new WorkspaceResource($workspace),
+            'Workspace retrieved successfully'
+        );
     }
 
     public function update(UpdateWorkspaceRequest $request, string $workspace): JsonResponse
     {
-        return $this->placeholder('Workspace update endpoint is not implemented yet');
+        $workspace = $this->accessibleWorkspace($request, $workspace);
+
+        if (! $workspace) {
+            return $this->forbidden();
+        }
+
+        $workspace->update($request->validated());
+
+        return ApiResponse::success(
+            new WorkspaceResource($workspace),
+            'Workspace updated successfully'
+        );
     }
 
-    public function destroy(string $workspace): JsonResponse
+    public function destroy(Request $request, string $workspace): JsonResponse
     {
-        return $this->placeholder('Workspace destroy endpoint is not implemented yet');
+        $workspace = $this->accessibleWorkspace($request, $workspace);
+
+        if (! $workspace) {
+            return $this->forbidden();
+        }
+
+        $workspace->delete();
+
+        return ApiResponse::success(
+            null,
+            'Workspace deleted successfully'
+        );
     }
 
-    private function placeholder(string $message): JsonResponse
+    private function accessibleWorkspace(Request $request, string $workspace): ?Workspace
     {
-        return ApiResponse::error($message, [], 501);
+        return Workspace::query()
+            ->whereKey($workspace)
+            ->whereHas('teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function forbidden(): JsonResponse
+    {
+        return ApiResponse::error(
+            'Workspace access denied',
+            [
+                'workspace' => ['You do not have access to this workspace.'],
+            ],
+            403
+        );
     }
 }

--- a/apps/api/app/Http/Requests/Domain/StoreCommentRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreCommentRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCommentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreProjectMemberRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreProjectMemberRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreProjectMemberRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $projectId = $this->route('project');
+
+        return [
+            'user_id' => [
+                'required',
+                'integer',
+                Rule::exists('users', 'id'),
+                Rule::unique('project_user', 'user_id')
+                    ->where(fn ($query) => $query->where('project_id', $projectId)),
+            ],
+        ];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreProjectRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreProjectRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Domain;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreProjectRequest extends FormRequest
 {
@@ -16,6 +17,29 @@ class StoreProjectRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        $workspaceId = $this->route('workspace');
+
+        return [
+            'team_id' => [
+                'required',
+                'integer',
+                Rule::exists('teams', 'id')
+                    ->where(fn ($query) => $query
+                        ->where('workspace_id', $workspaceId)
+                        ->whereNull('deleted_at')),
+            ],
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => [
+                'required',
+                'string',
+                'max:255',
+                'alpha_dash:ascii',
+                Rule::unique('projects', 'slug')
+                    ->where(fn ($query) => $query->where('workspace_id', $workspaceId)),
+            ],
+            'description' => ['nullable', 'string'],
+            'starts_at' => ['nullable', 'date'],
+            'ends_at' => ['nullable', 'date', 'after_or_equal:starts_at'],
+        ];
     }
 }

--- a/apps/api/app/Http/Requests/Domain/StoreProjectRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreProjectRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreProjectRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreTaskRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreTaskRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTaskRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreTaskStatusRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreTaskStatusRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTaskStatusRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreTeamMemberRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreTeamMemberRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreTeamMemberRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $teamId = $this->route('team');
+
+        return [
+            'user_id' => [
+                'required',
+                'integer',
+                Rule::exists('users', 'id'),
+                Rule::unique('team_user', 'user_id')
+                    ->where(fn ($query) => $query->where('team_id', $teamId)),
+            ],
+        ];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreTeamRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreTeamRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Domain;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreTeamRequest extends FormRequest
 {
@@ -16,6 +17,19 @@ class StoreTeamRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        $workspaceId = $this->route('workspace');
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => [
+                'required',
+                'string',
+                'max:255',
+                'alpha_dash:ascii',
+                Rule::unique('teams', 'slug')
+                    ->where(fn ($query) => $query->where('workspace_id', $workspaceId)),
+            ],
+            'description' => ['nullable', 'string'],
+        ];
     }
 }

--- a/apps/api/app/Http/Requests/Domain/StoreTeamRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreTeamRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTeamRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreWorkspaceRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreWorkspaceRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreWorkspaceRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreWorkspaceRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreWorkspaceRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Domain;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreWorkspaceRequest extends FormRequest
 {
@@ -16,6 +17,10 @@ class StoreWorkspaceRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => ['required', 'string', 'max:255', 'alpha_dash:ascii', Rule::unique('workspaces', 'slug')],
+            'description' => ['nullable', 'string'],
+        ];
     }
 }

--- a/apps/api/app/Http/Requests/Domain/UpdateCommentRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateCommentRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCommentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/UpdateProjectRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateProjectRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateProjectRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/UpdateProjectRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateProjectRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Domain;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateProjectRequest extends FormRequest
 {
@@ -16,6 +17,33 @@ class UpdateProjectRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        $workspaceId = $this->route('workspace');
+        $projectId = $this->route('project');
+
+        return [
+            'team_id' => [
+                'sometimes',
+                'required',
+                'integer',
+                Rule::exists('teams', 'id')
+                    ->where(fn ($query) => $query
+                        ->where('workspace_id', $workspaceId)
+                        ->whereNull('deleted_at')),
+            ],
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'slug' => [
+                'sometimes',
+                'required',
+                'string',
+                'max:255',
+                'alpha_dash:ascii',
+                Rule::unique('projects', 'slug')
+                    ->where(fn ($query) => $query->where('workspace_id', $workspaceId))
+                    ->ignore($projectId),
+            ],
+            'description' => ['nullable', 'string'],
+            'starts_at' => ['nullable', 'date'],
+            'ends_at' => ['nullable', 'date', 'after_or_equal:starts_at'],
+        ];
     }
 }

--- a/apps/api/app/Http/Requests/Domain/UpdateTaskRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateTaskRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateTaskRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/UpdateTaskStatusRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateTaskStatusRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateTaskStatusRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/UpdateTeamRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateTeamRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Domain;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateTeamRequest extends FormRequest
 {
@@ -16,6 +17,22 @@ class UpdateTeamRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        $workspaceId = $this->route('workspace');
+        $teamId = $this->route('team');
+
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'slug' => [
+                'sometimes',
+                'required',
+                'string',
+                'max:255',
+                'alpha_dash:ascii',
+                Rule::unique('teams', 'slug')
+                    ->where(fn ($query) => $query->where('workspace_id', $workspaceId))
+                    ->ignore($teamId),
+            ],
+            'description' => ['nullable', 'string'],
+        ];
     }
 }

--- a/apps/api/app/Http/Requests/Domain/UpdateTeamRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateTeamRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateTeamRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/UpdateWorkspaceRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateWorkspaceRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateWorkspaceRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/UpdateWorkspaceRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateWorkspaceRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Domain;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateWorkspaceRequest extends FormRequest
 {
@@ -16,6 +17,19 @@ class UpdateWorkspaceRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        $workspaceId = $this->route('workspace');
+
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'slug' => [
+                'sometimes',
+                'required',
+                'string',
+                'max:255',
+                'alpha_dash:ascii',
+                Rule::unique('workspaces', 'slug')->ignore($workspaceId),
+            ],
+            'description' => ['nullable', 'string'],
+        ];
     }
 }

--- a/apps/api/app/Http/Resources/CommentResource.php
+++ b/apps/api/app/Http/Resources/CommentResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CommentResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'task_id' => $this->task_id,
+            'user_id' => $this->user_id,
+            'body' => $this->body,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/ProjectResource.php
+++ b/apps/api/app/Http/Resources/ProjectResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ProjectResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'workspace_id' => $this->workspace_id,
+            'team_id' => $this->team_id,
+            'created_by' => $this->created_by,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'description' => $this->description,
+            'starts_at' => $this->starts_at,
+            'ends_at' => $this->ends_at,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/ProjectResource.php
+++ b/apps/api/app/Http/Resources/ProjectResource.php
@@ -19,7 +19,6 @@ class ProjectResource extends JsonResource
             'created_by' => $this->created_by,
             'name' => $this->name,
             'slug' => $this->slug,
-            'description' => $this->description,
             'starts_at' => $this->starts_at,
             'ends_at' => $this->ends_at,
             'created_at' => $this->created_at,

--- a/apps/api/app/Http/Resources/TaskResource.php
+++ b/apps/api/app/Http/Resources/TaskResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TaskResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'project_id' => $this->project_id,
+            'task_status_id' => $this->task_status_id,
+            'created_by' => $this->created_by,
+            'assigned_to' => $this->assigned_to,
+            'title' => $this->title,
+            'description' => $this->description,
+            'priority' => $this->priority,
+            'due_date' => $this->due_date,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/TaskStatusResource.php
+++ b/apps/api/app/Http/Resources/TaskStatusResource.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TaskStatusResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'workspace_id' => $this->workspace_id,
+            'project_id' => $this->project_id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'color' => $this->color,
+            'position' => $this->position,
+            'is_default' => $this->is_default,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/TeamResource.php
+++ b/apps/api/app/Http/Resources/TeamResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TeamResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'workspace_id' => $this->workspace_id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'description' => $this->description,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/TeamResource.php
+++ b/apps/api/app/Http/Resources/TeamResource.php
@@ -17,7 +17,6 @@ class TeamResource extends JsonResource
             'workspace_id' => $this->workspace_id,
             'name' => $this->name,
             'slug' => $this->slug,
-            'description' => $this->description,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/apps/api/app/Http/Resources/UserResource.php
+++ b/apps/api/app/Http/Resources/UserResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class UserResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+            'created_at' => $this->created_at,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/WorkspaceResource.php
+++ b/apps/api/app/Http/Resources/WorkspaceResource.php
@@ -16,7 +16,6 @@ class WorkspaceResource extends JsonResource
             'id' => $this->id,
             'name' => $this->name,
             'slug' => $this->slug,
-            'description' => $this->description,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/apps/api/app/Http/Resources/WorkspaceResource.php
+++ b/apps/api/app/Http/Resources/WorkspaceResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class WorkspaceResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'description' => $this->description,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -1,8 +1,14 @@
 <?php
 
 use App\Http\Controllers\Api\AuthController;
+use App\Http\Controllers\Api\CommentController;
 use App\Http\Controllers\Api\EmailVerificationController;
 use App\Http\Controllers\Api\PasswordResetController;
+use App\Http\Controllers\Api\ProjectController;
+use App\Http\Controllers\Api\TaskController;
+use App\Http\Controllers\Api\TaskStatusController;
+use App\Http\Controllers\Api\TeamController;
+use App\Http\Controllers\Api\WorkspaceController;
 use App\Support\ApiResponse;
 use Illuminate\Support\Facades\Route;
 
@@ -24,4 +30,12 @@ Route::middleware(['auth:sanctum', 'not.disabled'])->group(function () {
     Route::post('/logout', [AuthController::class, 'logout']);
     Route::get('/me', [AuthController::class, 'me']);
     Route::post('/email/verification-notification', [EmailVerificationController::class, 'resend']);
+
+    Route::apiResource('workspaces', WorkspaceController::class);
+    Route::apiResource('workspaces.teams', TeamController::class);
+    Route::apiResource('workspaces.projects', ProjectController::class);
+    Route::apiResource('projects.task-statuses', TaskStatusController::class)
+        ->parameters(['task-statuses' => 'taskStatus']);
+    Route::apiResource('projects.tasks', TaskController::class);
+    Route::apiResource('tasks.comments', CommentController::class);
 });

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Api\CommentController;
 use App\Http\Controllers\Api\EmailVerificationController;
 use App\Http\Controllers\Api\PasswordResetController;
 use App\Http\Controllers\Api\ProjectController;
+use App\Http\Controllers\Api\ProjectMemberController;
 use App\Http\Controllers\Api\TaskController;
 use App\Http\Controllers\Api\TaskStatusController;
 use App\Http\Controllers\Api\TeamController;
@@ -37,6 +38,9 @@ Route::middleware(['auth:sanctum', 'not.disabled'])->group(function () {
     Route::post('/workspaces/{workspace}/teams/{team}/members', [TeamMemberController::class, 'store']);
     Route::delete('/workspaces/{workspace}/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy']);
     Route::apiResource('workspaces.teams', TeamController::class);
+    Route::get('/workspaces/{workspace}/projects/{project}/members', [ProjectMemberController::class, 'index']);
+    Route::post('/workspaces/{workspace}/projects/{project}/members', [ProjectMemberController::class, 'store']);
+    Route::delete('/workspaces/{workspace}/projects/{project}/members/{user}', [ProjectMemberController::class, 'destroy']);
     Route::apiResource('workspaces.projects', ProjectController::class);
     Route::apiResource('projects.task-statuses', TaskStatusController::class)
         ->parameters(['task-statuses' => 'taskStatus']);

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Api\ProjectController;
 use App\Http\Controllers\Api\TaskController;
 use App\Http\Controllers\Api\TaskStatusController;
 use App\Http\Controllers\Api\TeamController;
+use App\Http\Controllers\Api\TeamMemberController;
 use App\Http\Controllers\Api\WorkspaceController;
 use App\Support\ApiResponse;
 use Illuminate\Support\Facades\Route;
@@ -32,6 +33,9 @@ Route::middleware(['auth:sanctum', 'not.disabled'])->group(function () {
     Route::post('/email/verification-notification', [EmailVerificationController::class, 'resend']);
 
     Route::apiResource('workspaces', WorkspaceController::class);
+    Route::get('/workspaces/{workspace}/teams/{team}/members', [TeamMemberController::class, 'index']);
+    Route::post('/workspaces/{workspace}/teams/{team}/members', [TeamMemberController::class, 'store']);
+    Route::delete('/workspaces/{workspace}/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy']);
     Route::apiResource('workspaces.teams', TeamController::class);
     Route::apiResource('workspaces.projects', ProjectController::class);
     Route::apiResource('projects.task-statuses', TaskStatusController::class)

--- a/apps/api/tests/Feature/DomainRoutesTest.php
+++ b/apps/api/tests/Feature/DomainRoutesTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects domain routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/workspaces'],
+    ['POST', '/api/workspaces'],
+    ['GET', '/api/workspaces/1/teams'],
+    ['GET', '/api/workspaces/1/projects'],
+    ['GET', '/api/projects/1/task-statuses'],
+    ['GET', '/api/projects/1/tasks'],
+    ['GET', '/api/tasks/1/comments'],
+]);
+
+it('blocks disabled authenticated users from domain routes', function () {
+    $user = User::factory()->create([
+        'email' => 'disabled-domain@example.com',
+    ]);
+
+    $this->postJson('/api/login', [
+        'email' => 'disabled-domain@example.com',
+        'password' => 'password',
+    ])->assertOk();
+
+    $user->forceFill([
+        'disabled_at' => now(),
+    ])->save();
+
+    $this->getJson('/api/workspaces')
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Account is disabled',
+            'errors' => [
+                'account' => ['This account has been disabled.'],
+            ],
+        ]);
+});

--- a/apps/api/tests/Feature/ProjectMemberRoutesTest.php
+++ b/apps/api/tests/Feature/ProjectMemberRoutesTest.php
@@ -1,0 +1,256 @@
+<?php
+
+use App\Models\Project;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects project member routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/workspaces/1/projects/1/members'],
+    ['POST', '/api/workspaces/1/projects/1/members'],
+    ['DELETE', '/api/workspaces/1/projects/1/members/1'],
+]);
+
+it('lists project members for an accessible project', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-list-manager@example.com',
+        'name' => 'Manager User',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'project-member-list-member@example.com',
+        'name' => 'Member User',
+    ]);
+    [$workspace, $project] = projectMemberEndpointProjectForUser($manager);
+
+    $project->users()->attach($member->id);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->getJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Project members retrieved successfully',
+        ])
+        ->assertJsonFragment([
+            'id' => $member->id,
+            'name' => 'Member User',
+            'email' => 'project-member-list-member@example.com',
+        ]);
+});
+
+it('adds a member to an accessible project', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-add-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'project-member-add-member@example.com',
+        'name' => 'Added Member',
+    ]);
+    [$workspace, $project] = projectMemberEndpointProjectForUser($manager);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertCreated()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Project member added successfully',
+            'data' => [
+                'id' => $member->id,
+                'name' => 'Added Member',
+                'email' => 'project-member-add-member@example.com',
+            ],
+        ]);
+
+    $this->assertDatabaseHas('project_user', [
+        'project_id' => $project->id,
+        'user_id' => $member->id,
+    ]);
+});
+
+it('returns validation errors when adding an invalid project member', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-validation@example.com',
+    ]);
+    [$workspace, $project] = projectMemberEndpointProjectForUser($manager);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members", [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'user_id',
+        ]);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members", [
+        'user_id' => 999999,
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'user_id',
+        ]);
+});
+
+it('rejects duplicate project membership', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-duplicate-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'project-member-duplicate-member@example.com',
+    ]);
+    [$workspace, $project] = projectMemberEndpointProjectForUser($manager);
+
+    $project->users()->attach($member->id);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'user_id',
+        ]);
+});
+
+it('removes a member from an accessible project', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-remove-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'project-member-remove-member@example.com',
+    ]);
+    [$workspace, $project] = projectMemberEndpointProjectForUser($manager);
+
+    $project->users()->attach($member->id);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->deleteJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members/{$member->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Project member removed successfully',
+            'data' => null,
+        ]);
+
+    $this->assertDatabaseMissing('project_user', [
+        'project_id' => $project->id,
+        'user_id' => $member->id,
+    ]);
+});
+
+it('forbids inaccessible project membership management', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-forbidden-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'project-member-forbidden-member@example.com',
+    ]);
+    [$accessibleWorkspace] = projectMemberEndpointProjectForUser($manager);
+    $hiddenWorkspace = Workspace::factory()->create();
+    $hiddenTeam = Team::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+    ]);
+    $hiddenProject = Project::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+        'team_id' => $hiddenTeam->id,
+    ]);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->getJson("/api/workspaces/{$hiddenWorkspace->id}/projects/{$hiddenProject->id}/members")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+            'errors' => [
+                'project' => ['You do not have access to this project.'],
+            ],
+        ]);
+
+    $this->postJson("/api/workspaces/{$accessibleWorkspace->id}/projects/{$hiddenProject->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+        ]);
+
+    $this->deleteJson("/api/workspaces/{$accessibleWorkspace->id}/projects/{$hiddenProject->id}/members/{$member->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+        ]);
+});
+
+it('does not expose sensitive user fields in project member responses', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-safe-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'project-member-safe-member@example.com',
+    ]);
+    [$workspace, $project] = projectMemberEndpointProjectForUser($manager);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertCreated()
+        ->assertJsonMissingPath('data.password')
+        ->assertJsonMissingPath('data.remember_token')
+        ->assertJsonMissingPath('data.email_verified_at')
+        ->assertJsonMissingPath('data.disabled_at')
+        ->assertJsonMissingPath('data.roles')
+        ->assertJsonMissingPath('data.permissions');
+
+    $this->getJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members")
+        ->assertOk()
+        ->assertJsonMissingPath('data.0.password')
+        ->assertJsonMissingPath('data.0.remember_token')
+        ->assertJsonMissingPath('data.0.email_verified_at')
+        ->assertJsonMissingPath('data.0.disabled_at')
+        ->assertJsonMissingPath('data.0.roles')
+        ->assertJsonMissingPath('data.0.permissions');
+});
+
+function projectMemberEndpointLoginAs(User $user): void
+{
+    test()->postJson('/api/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertOk();
+}
+
+/**
+ * @return array{Workspace, Project}
+ */
+function projectMemberEndpointProjectForUser(User $user): array
+{
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+    $project = Project::factory()->create([
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'created_by' => $user->id,
+    ]);
+
+    $team->users()->attach($user->id);
+
+    return [$workspace, $project];
+}

--- a/apps/api/tests/Feature/ProjectRoutesTest.php
+++ b/apps/api/tests/Feature/ProjectRoutesTest.php
@@ -1,0 +1,340 @@
+<?php
+
+use App\Models\Project;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects project routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/workspaces/1/projects'],
+    ['POST', '/api/workspaces/1/projects'],
+    ['GET', '/api/workspaces/1/projects/1'],
+    ['PATCH', '/api/workspaces/1/projects/1'],
+    ['DELETE', '/api/workspaces/1/projects/1'],
+]);
+
+it('creates a project in an accessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'project-create@example.com',
+    ]);
+    [$workspace, $team] = projectEndpointWorkspaceForUser($user);
+
+    projectEndpointLoginAs($user);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects", [
+        'team_id' => $team->id,
+        'name' => 'Billing Portal',
+        'slug' => 'billing-portal',
+        'description' => 'Customer billing work.',
+        'starts_at' => '2026-06-01',
+        'ends_at' => '2026-07-01',
+    ])
+        ->assertCreated()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Project created successfully',
+            'data' => [
+                'workspace_id' => $workspace->id,
+                'team_id' => $team->id,
+                'created_by' => $user->id,
+                'name' => 'Billing Portal',
+                'slug' => 'billing-portal',
+            ],
+        ])
+        ->assertJsonMissingPath('data.description');
+
+    $this->assertDatabaseHas('projects', [
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'created_by' => $user->id,
+        'name' => 'Billing Portal',
+        'slug' => 'billing-portal',
+    ]);
+});
+
+it('returns validation errors when creating a project with invalid data', function () {
+    $user = User::factory()->create([
+        'email' => 'project-validation@example.com',
+    ]);
+    [$workspace] = projectEndpointWorkspaceForUser($user);
+
+    projectEndpointLoginAs($user);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects", [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'team_id',
+            'name',
+            'slug',
+        ]);
+});
+
+it('rejects duplicate project slugs within the same workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'project-duplicate@example.com',
+    ]);
+    [$workspace, $team] = projectEndpointWorkspaceForUser($user);
+
+    Project::factory()->create([
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'slug' => 'duplicate-project',
+    ]);
+
+    projectEndpointLoginAs($user);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects", [
+        'team_id' => $team->id,
+        'name' => 'Duplicate Project',
+        'slug' => 'duplicate-project',
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'slug',
+        ]);
+});
+
+it('lists only projects in an accessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'project-index@example.com',
+    ]);
+    [$workspace, $team] = projectEndpointWorkspaceForUser($user);
+    $visibleProject = Project::factory()->create([
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'created_by' => $user->id,
+        'name' => 'Visible Project',
+        'slug' => 'visible-project',
+    ]);
+
+    Project::factory()->create([
+        'name' => 'Hidden Project',
+        'slug' => 'hidden-project',
+    ]);
+
+    projectEndpointLoginAs($user);
+
+    $this->getJson("/api/workspaces/{$workspace->id}/projects")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Projects retrieved successfully',
+        ])
+        ->assertJsonFragment([
+            'id' => $visibleProject->id,
+            'workspace_id' => $workspace->id,
+            'team_id' => $team->id,
+            'created_by' => $user->id,
+            'name' => 'Visible Project',
+            'slug' => 'visible-project',
+        ])
+        ->assertJsonMissing([
+            'slug' => 'hidden-project',
+        ]);
+});
+
+it('shows an accessible project', function () {
+    $user = User::factory()->create([
+        'email' => 'project-show@example.com',
+    ]);
+    [$workspace, $team] = projectEndpointWorkspaceForUser($user);
+    $project = Project::factory()->create([
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'created_by' => $user->id,
+        'name' => 'Visible Project',
+        'slug' => 'visible-project',
+    ]);
+
+    projectEndpointLoginAs($user);
+
+    $this->getJson("/api/workspaces/{$workspace->id}/projects/{$project->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Project retrieved successfully',
+            'data' => [
+                'id' => $project->id,
+                'workspace_id' => $workspace->id,
+                'team_id' => $team->id,
+                'created_by' => $user->id,
+                'name' => 'Visible Project',
+                'slug' => 'visible-project',
+            ],
+        ])
+        ->assertJsonMissingPath('data.description');
+});
+
+it('forbids inaccessible project and workspace access', function () {
+    $user = User::factory()->create([
+        'email' => 'project-show-forbidden@example.com',
+    ]);
+    [$accessibleWorkspace] = projectEndpointWorkspaceForUser($user);
+    $hiddenWorkspace = Workspace::factory()->create();
+    $hiddenTeam = Team::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+    ]);
+    $hiddenProject = Project::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+        'team_id' => $hiddenTeam->id,
+    ]);
+
+    projectEndpointLoginAs($user);
+
+    $this->getJson("/api/workspaces/{$hiddenWorkspace->id}/projects")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+            'errors' => [
+                'project' => ['You do not have access to this project.'],
+            ],
+        ]);
+
+    $this->getJson("/api/workspaces/{$accessibleWorkspace->id}/projects/{$hiddenProject->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+        ]);
+});
+
+it('updates an accessible project', function () {
+    $user = User::factory()->create([
+        'email' => 'project-update@example.com',
+    ]);
+    [$workspace, $team] = projectEndpointWorkspaceForUser($user);
+    $project = Project::factory()->create([
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'created_by' => $user->id,
+        'slug' => 'before-update',
+    ]);
+
+    projectEndpointLoginAs($user);
+
+    $this->patchJson("/api/workspaces/{$workspace->id}/projects/{$project->id}", [
+        'name' => 'After Update',
+        'slug' => 'after-update',
+    ])
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Project updated successfully',
+            'data' => [
+                'id' => $project->id,
+                'workspace_id' => $workspace->id,
+                'team_id' => $team->id,
+                'name' => 'After Update',
+                'slug' => 'after-update',
+            ],
+        ]);
+
+    $this->assertDatabaseHas('projects', [
+        'id' => $project->id,
+        'name' => 'After Update',
+        'slug' => 'after-update',
+    ]);
+});
+
+it('forbids updating an inaccessible project', function () {
+    $user = User::factory()->create([
+        'email' => 'project-update-forbidden@example.com',
+    ]);
+    [$accessibleWorkspace] = projectEndpointWorkspaceForUser($user);
+    $hiddenProject = Project::factory()->create([
+        'name' => 'Do Not Touch',
+    ]);
+
+    projectEndpointLoginAs($user);
+
+    $this->patchJson("/api/workspaces/{$accessibleWorkspace->id}/projects/{$hiddenProject->id}", [
+        'name' => 'Changed Anyway',
+    ])
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+        ]);
+
+    $this->assertDatabaseHas('projects', [
+        'id' => $hiddenProject->id,
+        'name' => 'Do Not Touch',
+    ]);
+});
+
+it('soft deletes an accessible project', function () {
+    $user = User::factory()->create([
+        'email' => 'project-delete@example.com',
+    ]);
+    [$workspace, $team] = projectEndpointWorkspaceForUser($user);
+    $project = Project::factory()->create([
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'created_by' => $user->id,
+    ]);
+
+    projectEndpointLoginAs($user);
+
+    $this->deleteJson("/api/workspaces/{$workspace->id}/projects/{$project->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Project deleted successfully',
+            'data' => null,
+        ]);
+
+    $this->assertSoftDeleted('projects', [
+        'id' => $project->id,
+    ]);
+});
+
+it('forbids deleting an inaccessible project', function () {
+    $user = User::factory()->create([
+        'email' => 'project-delete-forbidden@example.com',
+    ]);
+    [$accessibleWorkspace] = projectEndpointWorkspaceForUser($user);
+    $hiddenProject = Project::factory()->create();
+
+    projectEndpointLoginAs($user);
+
+    $this->deleteJson("/api/workspaces/{$accessibleWorkspace->id}/projects/{$hiddenProject->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+        ]);
+
+    $this->assertNotSoftDeleted('projects', [
+        'id' => $hiddenProject->id,
+    ]);
+});
+
+function projectEndpointLoginAs(User $user): void
+{
+    test()->postJson('/api/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertOk();
+}
+
+/**
+ * @return array{Workspace, Team}
+ */
+function projectEndpointWorkspaceForUser(User $user): array
+{
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+
+    $team->users()->attach($user->id);
+
+    return [$workspace, $team];
+}

--- a/apps/api/tests/Feature/TeamMemberRoutesTest.php
+++ b/apps/api/tests/Feature/TeamMemberRoutesTest.php
@@ -1,0 +1,251 @@
+<?php
+
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects team member routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/workspaces/1/teams/1/members'],
+    ['POST', '/api/workspaces/1/teams/1/members'],
+    ['DELETE', '/api/workspaces/1/teams/1/members/1'],
+]);
+
+it('lists team members for an accessible team', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-list-manager@example.com',
+        'name' => 'Manager User',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'team-member-list-member@example.com',
+        'name' => 'Member User',
+    ]);
+    [$workspace, $team] = teamMemberEndpointTeamForUser($manager);
+
+    $team->users()->attach($member->id);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->getJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Team members retrieved successfully',
+        ])
+        ->assertJsonFragment([
+            'id' => $manager->id,
+            'name' => 'Manager User',
+            'email' => 'team-member-list-manager@example.com',
+        ])
+        ->assertJsonFragment([
+            'id' => $member->id,
+            'name' => 'Member User',
+            'email' => 'team-member-list-member@example.com',
+        ]);
+});
+
+it('adds a member to an accessible team', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-add-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'team-member-add-member@example.com',
+        'name' => 'Added Member',
+    ]);
+    [$workspace, $team] = teamMemberEndpointTeamForUser($manager);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertCreated()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Team member added successfully',
+            'data' => [
+                'id' => $member->id,
+                'name' => 'Added Member',
+                'email' => 'team-member-add-member@example.com',
+            ],
+        ]);
+
+    $this->assertDatabaseHas('team_user', [
+        'team_id' => $team->id,
+        'user_id' => $member->id,
+    ]);
+});
+
+it('returns validation errors when adding an invalid team member', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-validation@example.com',
+    ]);
+    [$workspace, $team] = teamMemberEndpointTeamForUser($manager);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members", [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'user_id',
+        ]);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members", [
+        'user_id' => 999999,
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'user_id',
+        ]);
+});
+
+it('rejects duplicate team membership', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-duplicate-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'team-member-duplicate-member@example.com',
+    ]);
+    [$workspace, $team] = teamMemberEndpointTeamForUser($manager);
+
+    $team->users()->attach($member->id);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'user_id',
+        ]);
+});
+
+it('removes a member from an accessible team', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-remove-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'team-member-remove-member@example.com',
+    ]);
+    [$workspace, $team] = teamMemberEndpointTeamForUser($manager);
+
+    $team->users()->attach($member->id);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->deleteJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members/{$member->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Team member removed successfully',
+            'data' => null,
+        ]);
+
+    $this->assertDatabaseMissing('team_user', [
+        'team_id' => $team->id,
+        'user_id' => $member->id,
+    ]);
+});
+
+it('forbids inaccessible team membership management', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-forbidden-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'team-member-forbidden-member@example.com',
+    ]);
+    [$accessibleWorkspace] = teamMemberEndpointTeamForUser($manager);
+    $hiddenWorkspace = Workspace::factory()->create();
+    $hiddenTeam = Team::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+    ]);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->getJson("/api/workspaces/{$hiddenWorkspace->id}/teams/{$hiddenTeam->id}/members")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+            'errors' => [
+                'team' => ['You do not have access to this team.'],
+            ],
+        ]);
+
+    $this->postJson("/api/workspaces/{$accessibleWorkspace->id}/teams/{$hiddenTeam->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+        ]);
+
+    $this->deleteJson("/api/workspaces/{$accessibleWorkspace->id}/teams/{$hiddenTeam->id}/members/{$member->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+        ]);
+});
+
+it('does not expose sensitive user fields in member responses', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-safe-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'team-member-safe-member@example.com',
+    ]);
+    [$workspace, $team] = teamMemberEndpointTeamForUser($manager);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertCreated()
+        ->assertJsonMissingPath('data.password')
+        ->assertJsonMissingPath('data.remember_token')
+        ->assertJsonMissingPath('data.email_verified_at')
+        ->assertJsonMissingPath('data.disabled_at')
+        ->assertJsonMissingPath('data.roles')
+        ->assertJsonMissingPath('data.permissions');
+
+    $this->getJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members")
+        ->assertOk()
+        ->assertJsonMissingPath('data.0.password')
+        ->assertJsonMissingPath('data.0.remember_token')
+        ->assertJsonMissingPath('data.0.email_verified_at')
+        ->assertJsonMissingPath('data.0.disabled_at')
+        ->assertJsonMissingPath('data.0.roles')
+        ->assertJsonMissingPath('data.0.permissions');
+});
+
+function teamMemberEndpointLoginAs(User $user): void
+{
+    test()->postJson('/api/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertOk();
+}
+
+/**
+ * @return array{Workspace, Team}
+ */
+function teamMemberEndpointTeamForUser(User $user): array
+{
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+
+    $team->users()->attach($user->id);
+
+    return [$workspace, $team];
+}

--- a/apps/api/tests/Feature/TeamRoutesTest.php
+++ b/apps/api/tests/Feature/TeamRoutesTest.php
@@ -1,0 +1,323 @@
+<?php
+
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects team routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/workspaces/1/teams'],
+    ['POST', '/api/workspaces/1/teams'],
+    ['GET', '/api/workspaces/1/teams/1'],
+    ['PATCH', '/api/workspaces/1/teams/1'],
+    ['DELETE', '/api/workspaces/1/teams/1'],
+]);
+
+it('creates a team in an accessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'team-create@example.com',
+    ]);
+
+    $workspace = teamEndpointWorkspaceForUser($user);
+
+    teamEndpointLoginAs($user);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams", [
+        'name' => 'Platform Team',
+        'slug' => 'platform-team',
+        'description' => 'Owns the shared platform.',
+    ])
+        ->assertCreated()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Team created successfully',
+            'data' => [
+                'workspace_id' => $workspace->id,
+                'name' => 'Platform Team',
+                'slug' => 'platform-team',
+            ],
+        ])
+        ->assertJsonMissingPath('data.description');
+
+    $this->assertDatabaseHas('teams', [
+        'workspace_id' => $workspace->id,
+        'name' => 'Platform Team',
+        'slug' => 'platform-team',
+    ]);
+});
+
+it('returns validation errors when creating a team with invalid data', function () {
+    $user = User::factory()->create([
+        'email' => 'team-validation@example.com',
+    ]);
+
+    $workspace = teamEndpointWorkspaceForUser($user);
+
+    teamEndpointLoginAs($user);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams", [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'name',
+            'slug',
+        ]);
+});
+
+it('rejects duplicate team slugs within the same workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'team-duplicate@example.com',
+    ]);
+
+    $workspace = teamEndpointWorkspaceForUser($user);
+
+    Team::factory()->create([
+        'workspace_id' => $workspace->id,
+        'slug' => 'duplicate-team',
+    ]);
+
+    teamEndpointLoginAs($user);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams", [
+        'name' => 'Duplicate Team',
+        'slug' => 'duplicate-team',
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'slug',
+        ]);
+});
+
+it('lists teams only for an accessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'team-index@example.com',
+    ]);
+
+    $workspace = teamEndpointWorkspaceForUser($user);
+    $visibleTeam = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+        'name' => 'Visible Team',
+        'slug' => 'visible-team',
+    ]);
+
+    Team::factory()->create([
+        'workspace_id' => Workspace::factory()->create()->id,
+        'name' => 'Hidden Team',
+        'slug' => 'hidden-team',
+    ]);
+
+    teamEndpointLoginAs($user);
+
+    $this->getJson("/api/workspaces/{$workspace->id}/teams")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Teams retrieved successfully',
+        ])
+        ->assertJsonFragment([
+            'id' => $visibleTeam->id,
+            'workspace_id' => $workspace->id,
+            'name' => 'Visible Team',
+            'slug' => 'visible-team',
+        ])
+        ->assertJsonMissing([
+            'slug' => 'hidden-team',
+        ]);
+});
+
+it('shows an accessible team', function () {
+    $user = User::factory()->create([
+        'email' => 'team-show@example.com',
+    ]);
+
+    $workspace = teamEndpointWorkspaceForUser($user);
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+        'name' => 'Visible Team',
+        'slug' => 'visible-team',
+    ]);
+
+    teamEndpointLoginAs($user);
+
+    $this->getJson("/api/workspaces/{$workspace->id}/teams/{$team->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Team retrieved successfully',
+            'data' => [
+                'id' => $team->id,
+                'workspace_id' => $workspace->id,
+                'name' => 'Visible Team',
+                'slug' => 'visible-team',
+            ],
+        ])
+        ->assertJsonMissingPath('data.description');
+});
+
+it('forbids inaccessible workspace and team access', function () {
+    $user = User::factory()->create([
+        'email' => 'team-show-forbidden@example.com',
+    ]);
+
+    $accessibleWorkspace = teamEndpointWorkspaceForUser($user);
+    $hiddenWorkspace = Workspace::factory()->create();
+    $hiddenTeam = Team::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+    ]);
+
+    teamEndpointLoginAs($user);
+
+    $this->getJson("/api/workspaces/{$hiddenWorkspace->id}/teams")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+            'errors' => [
+                'team' => ['You do not have access to this team.'],
+            ],
+        ]);
+
+    $this->getJson("/api/workspaces/{$accessibleWorkspace->id}/teams/{$hiddenTeam->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+        ]);
+});
+
+it('updates an accessible team', function () {
+    $user = User::factory()->create([
+        'email' => 'team-update@example.com',
+    ]);
+
+    $workspace = teamEndpointWorkspaceForUser($user);
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+        'slug' => 'before-update',
+    ]);
+
+    teamEndpointLoginAs($user);
+
+    $this->patchJson("/api/workspaces/{$workspace->id}/teams/{$team->id}", [
+        'name' => 'After Update',
+        'slug' => 'after-update',
+    ])
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Team updated successfully',
+            'data' => [
+                'id' => $team->id,
+                'workspace_id' => $workspace->id,
+                'name' => 'After Update',
+                'slug' => 'after-update',
+            ],
+        ]);
+
+    $this->assertDatabaseHas('teams', [
+        'id' => $team->id,
+        'name' => 'After Update',
+        'slug' => 'after-update',
+    ]);
+});
+
+it('forbids updating an inaccessible team', function () {
+    $user = User::factory()->create([
+        'email' => 'team-update-forbidden@example.com',
+    ]);
+
+    $accessibleWorkspace = teamEndpointWorkspaceForUser($user);
+    $hiddenTeam = Team::factory()->create([
+        'name' => 'Do Not Touch',
+    ]);
+
+    teamEndpointLoginAs($user);
+
+    $this->patchJson("/api/workspaces/{$accessibleWorkspace->id}/teams/{$hiddenTeam->id}", [
+        'name' => 'Changed Anyway',
+    ])
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+        ]);
+
+    $this->assertDatabaseHas('teams', [
+        'id' => $hiddenTeam->id,
+        'name' => 'Do Not Touch',
+    ]);
+});
+
+it('soft deletes an accessible team', function () {
+    $user = User::factory()->create([
+        'email' => 'team-delete@example.com',
+    ]);
+
+    $workspace = teamEndpointWorkspaceForUser($user);
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+
+    teamEndpointLoginAs($user);
+
+    $this->deleteJson("/api/workspaces/{$workspace->id}/teams/{$team->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Team deleted successfully',
+            'data' => null,
+        ]);
+
+    $this->assertSoftDeleted('teams', [
+        'id' => $team->id,
+    ]);
+});
+
+it('forbids deleting an inaccessible team', function () {
+    $user = User::factory()->create([
+        'email' => 'team-delete-forbidden@example.com',
+    ]);
+
+    $accessibleWorkspace = teamEndpointWorkspaceForUser($user);
+    $hiddenTeam = Team::factory()->create();
+
+    teamEndpointLoginAs($user);
+
+    $this->deleteJson("/api/workspaces/{$accessibleWorkspace->id}/teams/{$hiddenTeam->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+        ]);
+
+    $this->assertNotSoftDeleted('teams', [
+        'id' => $hiddenTeam->id,
+    ]);
+});
+
+function teamEndpointLoginAs(User $user): void
+{
+    test()->postJson('/api/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertOk();
+}
+
+/**
+ * @param array<string, mixed> $attributes
+ */
+function teamEndpointWorkspaceForUser(User $user, array $attributes = []): Workspace
+{
+    $workspace = Workspace::factory()->create($attributes);
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+
+    $team->users()->attach($user->id);
+
+    return $workspace;
+}

--- a/apps/api/tests/Feature/WorkspaceRoutesTest.php
+++ b/apps/api/tests/Feature/WorkspaceRoutesTest.php
@@ -1,0 +1,300 @@
+<?php
+
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects workspace routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/workspaces'],
+    ['POST', '/api/workspaces'],
+    ['GET', '/api/workspaces/1'],
+    ['PATCH', '/api/workspaces/1'],
+    ['DELETE', '/api/workspaces/1'],
+]);
+
+it('creates a workspace and default team for the authenticated user', function () {
+    $user = User::factory()->create([
+        'email' => 'workspace-create@example.com',
+    ]);
+
+    loginAs($user);
+
+    $this->postJson('/api/workspaces', [
+        'name' => 'Product Engineering',
+        'slug' => 'product-engineering',
+        'description' => 'Internal product delivery workspace.',
+    ])
+        ->assertCreated()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Workspace created successfully',
+            'data' => [
+                'name' => 'Product Engineering',
+                'slug' => 'product-engineering',
+            ],
+        ])
+        ->assertJsonMissingPath('data.description');
+
+    $workspace = Workspace::where('slug', 'product-engineering')->firstOrFail();
+
+    $this->assertDatabaseHas('teams', [
+        'workspace_id' => $workspace->id,
+        'name' => 'Default Team',
+        'slug' => 'default-team',
+    ]);
+
+    $team = Team::where('workspace_id', $workspace->id)->firstOrFail();
+
+    $this->assertDatabaseHas('team_user', [
+        'team_id' => $team->id,
+        'user_id' => $user->id,
+    ]);
+});
+
+it('returns validation errors when creating a workspace with invalid data', function () {
+    $user = User::factory()->create([
+        'email' => 'workspace-validation@example.com',
+    ]);
+
+    loginAs($user);
+
+    $this->postJson('/api/workspaces', [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'name',
+            'slug',
+        ]);
+});
+
+it('rejects duplicate workspace slugs', function () {
+    Workspace::factory()->create([
+        'slug' => 'duplicate-workspace',
+    ]);
+
+    $user = User::factory()->create([
+        'email' => 'workspace-duplicate@example.com',
+    ]);
+
+    loginAs($user);
+
+    $this->postJson('/api/workspaces', [
+        'name' => 'Duplicate Workspace',
+        'slug' => 'duplicate-workspace',
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'slug',
+        ]);
+});
+
+it('lists only workspaces accessible through team membership', function () {
+    $user = User::factory()->create([
+        'email' => 'workspace-index@example.com',
+    ]);
+
+    $accessible = workspaceForUser($user, [
+        'name' => 'Accessible Workspace',
+        'slug' => 'accessible-workspace',
+    ]);
+
+    Workspace::factory()->create([
+        'name' => 'Hidden Workspace',
+        'slug' => 'hidden-workspace',
+    ]);
+
+    loginAs($user);
+
+    $this->getJson('/api/workspaces')
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Workspaces retrieved successfully',
+            'data' => [
+                [
+                    'id' => $accessible->id,
+                    'name' => 'Accessible Workspace',
+                    'slug' => 'accessible-workspace',
+                ],
+            ],
+        ])
+        ->assertJsonMissing([
+            'slug' => 'hidden-workspace',
+        ]);
+});
+
+it('shows an accessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'workspace-show@example.com',
+    ]);
+
+    $workspace = workspaceForUser($user, [
+        'name' => 'Visible Workspace',
+        'slug' => 'visible-workspace',
+    ]);
+
+    loginAs($user);
+
+    $this->getJson("/api/workspaces/{$workspace->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Workspace retrieved successfully',
+            'data' => [
+                'id' => $workspace->id,
+                'name' => 'Visible Workspace',
+                'slug' => 'visible-workspace',
+            ],
+        ])
+        ->assertJsonMissingPath('data.description');
+});
+
+it('forbids showing an inaccessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'workspace-show-forbidden@example.com',
+    ]);
+
+    $workspace = Workspace::factory()->create();
+
+    loginAs($user);
+
+    $this->getJson("/api/workspaces/{$workspace->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Workspace access denied',
+            'errors' => [
+                'workspace' => ['You do not have access to this workspace.'],
+            ],
+        ]);
+});
+
+it('updates an accessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'workspace-update@example.com',
+    ]);
+
+    $workspace = workspaceForUser($user, [
+        'slug' => 'before-update',
+    ]);
+
+    loginAs($user);
+
+    $this->patchJson("/api/workspaces/{$workspace->id}", [
+        'name' => 'After Update',
+        'slug' => 'after-update',
+    ])
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Workspace updated successfully',
+            'data' => [
+                'id' => $workspace->id,
+                'name' => 'After Update',
+                'slug' => 'after-update',
+            ],
+        ]);
+
+    $this->assertDatabaseHas('workspaces', [
+        'id' => $workspace->id,
+        'name' => 'After Update',
+        'slug' => 'after-update',
+    ]);
+});
+
+it('forbids updating an inaccessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'workspace-update-forbidden@example.com',
+    ]);
+
+    $workspace = Workspace::factory()->create([
+        'name' => 'Do Not Touch',
+    ]);
+
+    loginAs($user);
+
+    $this->patchJson("/api/workspaces/{$workspace->id}", [
+        'name' => 'Changed Anyway',
+    ])
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Workspace access denied',
+        ]);
+
+    $this->assertDatabaseHas('workspaces', [
+        'id' => $workspace->id,
+        'name' => 'Do Not Touch',
+    ]);
+});
+
+it('soft deletes an accessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'workspace-delete@example.com',
+    ]);
+
+    $workspace = workspaceForUser($user);
+
+    loginAs($user);
+
+    $this->deleteJson("/api/workspaces/{$workspace->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Workspace deleted successfully',
+            'data' => null,
+        ]);
+
+    $this->assertSoftDeleted('workspaces', [
+        'id' => $workspace->id,
+    ]);
+});
+
+it('forbids deleting an inaccessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'workspace-delete-forbidden@example.com',
+    ]);
+
+    $workspace = Workspace::factory()->create();
+
+    loginAs($user);
+
+    $this->deleteJson("/api/workspaces/{$workspace->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Workspace access denied',
+        ]);
+
+    $this->assertNotSoftDeleted('workspaces', [
+        'id' => $workspace->id,
+    ]);
+});
+
+function loginAs(User $user): void
+{
+    test()->postJson('/api/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertOk();
+}
+
+/**
+ * @param array<string, mixed> $attributes
+ */
+function workspaceForUser(User $user, array $attributes = []): Workspace
+{
+    $workspace = Workspace::factory()->create($attributes);
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+
+    $team->users()->attach($user->id);
+
+    return $workspace;
+}


### PR DESCRIPTION
## Summary

- Added authenticated project membership endpoints.
- Added project member listing, adding, and removing behavior.
- Added project member validation.
- Added project membership feature tests.

## What changed

Project membership can now be managed through protected API routes under workspace projects.

Membership management is scoped to accessible projects only. Duplicate project membership is rejected through validation, and responses use the existing safe `UserResource`.

## Testing

- Backend test suite passed with Pest.

## Notes

- No frontend work was added.
- No project roles were implemented.
- No Phase 4 permission matrix logic was implemented.