### PR TITLE
feat: implement project membership endpoints

### DIFF
--- a/apps/api/app/Http/Controllers/Api/ProjectMemberController.php
+++ b/apps/api/app/Http/Controllers/Api/ProjectMemberController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreProjectMemberRequest;
+use App\Http\Resources\UserResource;
+use App\Models\Project;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ProjectMemberController extends Controller
+{
+    public function index(Request $request, string $workspace, string $project): JsonResponse
+    {
+        $project = $this->accessibleProject($request, $workspace, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $members = $project->users()
+            ->orderBy('name')
+            ->get();
+
+        return ApiResponse::success(
+            UserResource::collection($members),
+            'Project members retrieved successfully'
+        );
+    }
+
+    public function store(StoreProjectMemberRequest $request, string $workspace, string $project): JsonResponse
+    {
+        $project = $this->accessibleProject($request, $workspace, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $project->users()->attach($request->validated('user_id'));
+
+        $member = $project->users()
+            ->whereKey($request->validated('user_id'))
+            ->firstOrFail();
+
+        return ApiResponse::success(
+            new UserResource($member),
+            'Project member added successfully',
+            201
+        );
+    }
+
+    public function destroy(Request $request, string $workspace, string $project, string $user): JsonResponse
+    {
+        $project = $this->accessibleProject($request, $workspace, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $project->users()->detach($user);
+
+        return ApiResponse::success(
+            null,
+            'Project member removed successfully'
+        );
+    }
+
+    private function accessibleProject(Request $request, string $workspace, string $project): ?Project
+    {
+        return Project::query()
+            ->whereKey($project)
+            ->where('workspace_id', $workspace)
+            ->whereHas('workspace.teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function forbidden(): JsonResponse
+    {
+        return ApiResponse::error(
+            'Project access denied',
+            [
+                'project' => ['You do not have access to this project.'],
+            ],
+            403
+        );
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreProjectMemberRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreProjectMemberRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreProjectMemberRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $projectId = $this->route('project');
+
+        return [
+            'user_id' => [
+                'required',
+                'integer',
+                Rule::exists('users', 'id'),
+                Rule::unique('project_user', 'user_id')
+                    ->where(fn ($query) => $query->where('project_id', $projectId)),
+            ],
+        ];
+    }
+}

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Api\CommentController;
 use App\Http\Controllers\Api\EmailVerificationController;
 use App\Http\Controllers\Api\PasswordResetController;
 use App\Http\Controllers\Api\ProjectController;
+use App\Http\Controllers\Api\ProjectMemberController;
 use App\Http\Controllers\Api\TaskController;
 use App\Http\Controllers\Api\TaskStatusController;
 use App\Http\Controllers\Api\TeamController;
@@ -37,6 +38,9 @@ Route::middleware(['auth:sanctum', 'not.disabled'])->group(function () {
     Route::post('/workspaces/{workspace}/teams/{team}/members', [TeamMemberController::class, 'store']);
     Route::delete('/workspaces/{workspace}/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy']);
     Route::apiResource('workspaces.teams', TeamController::class);
+    Route::get('/workspaces/{workspace}/projects/{project}/members', [ProjectMemberController::class, 'index']);
+    Route::post('/workspaces/{workspace}/projects/{project}/members', [ProjectMemberController::class, 'store']);
+    Route::delete('/workspaces/{workspace}/projects/{project}/members/{user}', [ProjectMemberController::class, 'destroy']);
     Route::apiResource('workspaces.projects', ProjectController::class);
     Route::apiResource('projects.task-statuses', TaskStatusController::class)
         ->parameters(['task-statuses' => 'taskStatus']);

--- a/apps/api/tests/Feature/ProjectMemberRoutesTest.php
+++ b/apps/api/tests/Feature/ProjectMemberRoutesTest.php
@@ -1,0 +1,256 @@
+<?php
+
+use App\Models\Project;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects project member routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/workspaces/1/projects/1/members'],
+    ['POST', '/api/workspaces/1/projects/1/members'],
+    ['DELETE', '/api/workspaces/1/projects/1/members/1'],
+]);
+
+it('lists project members for an accessible project', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-list-manager@example.com',
+        'name' => 'Manager User',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'project-member-list-member@example.com',
+        'name' => 'Member User',
+    ]);
+    [$workspace, $project] = projectMemberEndpointProjectForUser($manager);
+
+    $project->users()->attach($member->id);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->getJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Project members retrieved successfully',
+        ])
+        ->assertJsonFragment([
+            'id' => $member->id,
+            'name' => 'Member User',
+            'email' => 'project-member-list-member@example.com',
+        ]);
+});
+
+it('adds a member to an accessible project', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-add-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'project-member-add-member@example.com',
+        'name' => 'Added Member',
+    ]);
+    [$workspace, $project] = projectMemberEndpointProjectForUser($manager);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertCreated()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Project member added successfully',
+            'data' => [
+                'id' => $member->id,
+                'name' => 'Added Member',
+                'email' => 'project-member-add-member@example.com',
+            ],
+        ]);
+
+    $this->assertDatabaseHas('project_user', [
+        'project_id' => $project->id,
+        'user_id' => $member->id,
+    ]);
+});
+
+it('returns validation errors when adding an invalid project member', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-validation@example.com',
+    ]);
+    [$workspace, $project] = projectMemberEndpointProjectForUser($manager);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members", [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'user_id',
+        ]);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members", [
+        'user_id' => 999999,
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'user_id',
+        ]);
+});
+
+it('rejects duplicate project membership', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-duplicate-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'project-member-duplicate-member@example.com',
+    ]);
+    [$workspace, $project] = projectMemberEndpointProjectForUser($manager);
+
+    $project->users()->attach($member->id);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'user_id',
+        ]);
+});
+
+it('removes a member from an accessible project', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-remove-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'project-member-remove-member@example.com',
+    ]);
+    [$workspace, $project] = projectMemberEndpointProjectForUser($manager);
+
+    $project->users()->attach($member->id);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->deleteJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members/{$member->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Project member removed successfully',
+            'data' => null,
+        ]);
+
+    $this->assertDatabaseMissing('project_user', [
+        'project_id' => $project->id,
+        'user_id' => $member->id,
+    ]);
+});
+
+it('forbids inaccessible project membership management', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-forbidden-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'project-member-forbidden-member@example.com',
+    ]);
+    [$accessibleWorkspace] = projectMemberEndpointProjectForUser($manager);
+    $hiddenWorkspace = Workspace::factory()->create();
+    $hiddenTeam = Team::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+    ]);
+    $hiddenProject = Project::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+        'team_id' => $hiddenTeam->id,
+    ]);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->getJson("/api/workspaces/{$hiddenWorkspace->id}/projects/{$hiddenProject->id}/members")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+            'errors' => [
+                'project' => ['You do not have access to this project.'],
+            ],
+        ]);
+
+    $this->postJson("/api/workspaces/{$accessibleWorkspace->id}/projects/{$hiddenProject->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+        ]);
+
+    $this->deleteJson("/api/workspaces/{$accessibleWorkspace->id}/projects/{$hiddenProject->id}/members/{$member->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+        ]);
+});
+
+it('does not expose sensitive user fields in project member responses', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-safe-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'project-member-safe-member@example.com',
+    ]);
+    [$workspace, $project] = projectMemberEndpointProjectForUser($manager);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertCreated()
+        ->assertJsonMissingPath('data.password')
+        ->assertJsonMissingPath('data.remember_token')
+        ->assertJsonMissingPath('data.email_verified_at')
+        ->assertJsonMissingPath('data.disabled_at')
+        ->assertJsonMissingPath('data.roles')
+        ->assertJsonMissingPath('data.permissions');
+
+    $this->getJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members")
+        ->assertOk()
+        ->assertJsonMissingPath('data.0.password')
+        ->assertJsonMissingPath('data.0.remember_token')
+        ->assertJsonMissingPath('data.0.email_verified_at')
+        ->assertJsonMissingPath('data.0.disabled_at')
+        ->assertJsonMissingPath('data.0.roles')
+        ->assertJsonMissingPath('data.0.permissions');
+});
+
+function projectMemberEndpointLoginAs(User $user): void
+{
+    test()->postJson('/api/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertOk();
+}
+
+/**
+ * @return array{Workspace, Project}
+ */
+function projectMemberEndpointProjectForUser(User $user): array
+{
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+    $project = Project::factory()->create([
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'created_by' => $user->id,
+    ]);
+
+    $team->users()->attach($user->id);
+
+    return [$workspace, $project];
+}


### PR DESCRIPTION
## Summary

- Added authenticated project membership endpoints.
- Added project member listing, adding, and removing behavior.
- Added project member validation.
- Added project membership feature tests.

## What changed

Project membership can now be managed through protected API routes under workspace projects.

Membership management is scoped to accessible projects only. Duplicate project membership is rejected through validation, and responses use the existing safe `UserResource`.

## Testing

- Backend test suite passed with Pest.

## Notes

- No frontend work was added.
- No project roles were implemented.
- No Phase 4 permission matrix logic was implemented.