### PR TITLE
feat: implement task status API endpoints

### DIFF
--- a/apps/api/app/Http/Controllers/Api/TaskStatusController.php
+++ b/apps/api/app/Http/Controllers/Api/TaskStatusController.php
@@ -5,38 +5,129 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Domain\StoreTaskStatusRequest;
 use App\Http\Requests\Domain\UpdateTaskStatusRequest;
+use App\Http\Resources\TaskStatusResource;
+use App\Models\Project;
+use App\Models\TaskStatus;
 use App\Support\ApiResponse;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 class TaskStatusController extends Controller
 {
-    public function index(string $project): JsonResponse
+    public function index(Request $request, string $project): JsonResponse
     {
-        return $this->placeholder('Task status index endpoint is not implemented yet');
+        $project = $this->accessibleProject($request, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $statuses = $project->taskStatuses()
+            ->orderBy('position')
+            ->orderBy('name')
+            ->get();
+
+        return ApiResponse::success(
+            TaskStatusResource::collection($statuses),
+            'Task statuses retrieved successfully'
+        );
     }
 
     public function store(StoreTaskStatusRequest $request, string $project): JsonResponse
     {
-        return $this->placeholder('Task status store endpoint is not implemented yet');
+        $project = $this->accessibleProject($request, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $status = $project->taskStatuses()->create([
+            ...$request->validated(),
+            'workspace_id' => $project->workspace_id,
+        ]);
+
+        return ApiResponse::success(
+            new TaskStatusResource($status),
+            'Task status created successfully',
+            201
+        );
     }
 
-    public function show(string $project, string $taskStatus): JsonResponse
+    public function show(Request $request, string $project, string $taskStatus): JsonResponse
     {
-        return $this->placeholder('Task status show endpoint is not implemented yet');
+        $status = $this->accessibleTaskStatus($request, $project, $taskStatus);
+
+        if (! $status) {
+            return $this->forbidden();
+        }
+
+        return ApiResponse::success(
+            new TaskStatusResource($status),
+            'Task status retrieved successfully'
+        );
     }
 
     public function update(UpdateTaskStatusRequest $request, string $project, string $taskStatus): JsonResponse
     {
-        return $this->placeholder('Task status update endpoint is not implemented yet');
+        $status = $this->accessibleTaskStatus($request, $project, $taskStatus);
+
+        if (! $status) {
+            return $this->forbidden();
+        }
+
+        $status->update($request->validated());
+
+        return ApiResponse::success(
+            new TaskStatusResource($status),
+            'Task status updated successfully'
+        );
     }
 
-    public function destroy(string $project, string $taskStatus): JsonResponse
+    public function destroy(Request $request, string $project, string $taskStatus): JsonResponse
     {
-        return $this->placeholder('Task status destroy endpoint is not implemented yet');
+        $status = $this->accessibleTaskStatus($request, $project, $taskStatus);
+
+        if (! $status) {
+            return $this->forbidden();
+        }
+
+        $status->delete();
+
+        return ApiResponse::success(
+            null,
+            'Task status deleted successfully'
+        );
     }
 
-    private function placeholder(string $message): JsonResponse
+    private function accessibleProject(Request $request, string $project): ?Project
     {
-        return ApiResponse::error($message, [], 501);
+        return Project::query()
+            ->whereKey($project)
+            ->whereHas('workspace.teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function accessibleTaskStatus(Request $request, string $project, string $taskStatus): ?TaskStatus
+    {
+        return TaskStatus::query()
+            ->whereKey($taskStatus)
+            ->where('project_id', $project)
+            ->whereHas('project.workspace.teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function forbidden(): JsonResponse
+    {
+        return ApiResponse::error(
+            'Task status access denied',
+            [
+                'task_status' => ['You do not have access to this task status.'],
+            ],
+            403
+        );
     }
 }

--- a/apps/api/app/Http/Requests/Domain/StoreTaskStatusRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreTaskStatusRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\Domain;
 
+use App\Models\Project;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreTaskStatusRequest extends FormRequest
 {
@@ -16,6 +18,23 @@ class StoreTaskStatusRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        $project = Project::find($this->route('project'));
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => [
+                'required',
+                'string',
+                'max:255',
+                'alpha_dash:ascii',
+                Rule::unique('task_statuses', 'slug')
+                    ->where(fn ($query) => $query
+                        ->where('workspace_id', $project?->workspace_id)
+                        ->where('project_id', $this->route('project'))),
+            ],
+            'color' => ['nullable', 'string', 'max:255'],
+            'position' => ['sometimes', 'integer', 'min:0', 'max:65535'],
+            'is_default' => ['sometimes', 'boolean'],
+        ];
     }
 }

--- a/apps/api/app/Http/Requests/Domain/UpdateTaskStatusRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateTaskStatusRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\Domain;
 
+use App\Models\Project;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateTaskStatusRequest extends FormRequest
 {
@@ -16,6 +18,26 @@ class UpdateTaskStatusRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        $project = Project::find($this->route('project'));
+        $taskStatusId = $this->route('taskStatus');
+
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'slug' => [
+                'sometimes',
+                'required',
+                'string',
+                'max:255',
+                'alpha_dash:ascii',
+                Rule::unique('task_statuses', 'slug')
+                    ->where(fn ($query) => $query
+                        ->where('workspace_id', $project?->workspace_id)
+                        ->where('project_id', $this->route('project')))
+                    ->ignore($taskStatusId),
+            ],
+            'color' => ['nullable', 'string', 'max:255'],
+            'position' => ['sometimes', 'integer', 'min:0', 'max:65535'],
+            'is_default' => ['sometimes', 'boolean'],
+        ];
     }
 }

--- a/apps/api/tests/Feature/TaskStatusRoutesTest.php
+++ b/apps/api/tests/Feature/TaskStatusRoutesTest.php
@@ -1,0 +1,344 @@
+<?php
+
+use App\Models\Project;
+use App\Models\TaskStatus;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects task status routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/projects/1/task-statuses'],
+    ['POST', '/api/projects/1/task-statuses'],
+    ['GET', '/api/projects/1/task-statuses/1'],
+    ['PATCH', '/api/projects/1/task-statuses/1'],
+    ['DELETE', '/api/projects/1/task-statuses/1'],
+]);
+
+it('creates a task status for an accessible project', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-create@example.com',
+    ]);
+    [$workspace, $project] = taskStatusEndpointProjectForUser($user);
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->postJson("/api/projects/{$project->id}/task-statuses", [
+        'name' => 'Ready for Review',
+        'slug' => 'ready-for-review',
+        'color' => '#44aa88',
+        'position' => 2,
+        'is_default' => true,
+    ])
+        ->assertCreated()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Task status created successfully',
+            'data' => [
+                'workspace_id' => $workspace->id,
+                'project_id' => $project->id,
+                'name' => 'Ready for Review',
+                'slug' => 'ready-for-review',
+                'color' => '#44aa88',
+                'position' => 2,
+                'is_default' => true,
+            ],
+        ]);
+
+    $this->assertDatabaseHas('task_statuses', [
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'name' => 'Ready for Review',
+        'slug' => 'ready-for-review',
+    ]);
+});
+
+it('returns validation errors when creating a task status with invalid data', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-validation@example.com',
+    ]);
+    [, $project] = taskStatusEndpointProjectForUser($user);
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->postJson("/api/projects/{$project->id}/task-statuses", [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'name',
+            'slug',
+        ]);
+});
+
+it('rejects duplicate task status slugs in the same project scope', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-duplicate@example.com',
+    ]);
+    [$workspace, $project] = taskStatusEndpointProjectForUser($user);
+
+    TaskStatus::factory()->create([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'slug' => 'duplicate-status',
+    ]);
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->postJson("/api/projects/{$project->id}/task-statuses", [
+        'name' => 'Duplicate Status',
+        'slug' => 'duplicate-status',
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'slug',
+        ]);
+});
+
+it('lists task statuses for an accessible project', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-index@example.com',
+    ]);
+    [$workspace, $project] = taskStatusEndpointProjectForUser($user);
+    $visibleStatus = TaskStatus::factory()->create([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'name' => 'Visible Status',
+        'slug' => 'visible-status',
+        'position' => 1,
+    ]);
+
+    TaskStatus::factory()->create([
+        'name' => 'Hidden Status',
+        'slug' => 'hidden-status',
+    ]);
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->getJson("/api/projects/{$project->id}/task-statuses")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Task statuses retrieved successfully',
+        ])
+        ->assertJsonFragment([
+            'id' => $visibleStatus->id,
+            'workspace_id' => $workspace->id,
+            'project_id' => $project->id,
+            'name' => 'Visible Status',
+            'slug' => 'visible-status',
+        ])
+        ->assertJsonMissing([
+            'slug' => 'hidden-status',
+        ]);
+});
+
+it('shows an accessible task status', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-show@example.com',
+    ]);
+    [$workspace, $project] = taskStatusEndpointProjectForUser($user);
+    $status = TaskStatus::factory()->create([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'name' => 'Visible Status',
+        'slug' => 'visible-status',
+    ]);
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->getJson("/api/projects/{$project->id}/task-statuses/{$status->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Task status retrieved successfully',
+            'data' => [
+                'id' => $status->id,
+                'workspace_id' => $workspace->id,
+                'project_id' => $project->id,
+                'name' => 'Visible Status',
+                'slug' => 'visible-status',
+            ],
+        ]);
+});
+
+it('forbids inaccessible project and task status access', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-forbidden@example.com',
+    ]);
+    [, $accessibleProject] = taskStatusEndpointProjectForUser($user);
+    $hiddenWorkspace = Workspace::factory()->create();
+    $hiddenTeam = Team::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+    ]);
+    $hiddenProject = Project::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+        'team_id' => $hiddenTeam->id,
+    ]);
+    $hiddenStatus = TaskStatus::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+        'project_id' => $hiddenProject->id,
+    ]);
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->getJson("/api/projects/{$hiddenProject->id}/task-statuses")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Task status access denied',
+            'errors' => [
+                'task_status' => ['You do not have access to this task status.'],
+            ],
+        ]);
+
+    $this->getJson("/api/projects/{$accessibleProject->id}/task-statuses/{$hiddenStatus->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Task status access denied',
+        ]);
+});
+
+it('updates an accessible task status', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-update@example.com',
+    ]);
+    [$workspace, $project] = taskStatusEndpointProjectForUser($user);
+    $status = TaskStatus::factory()->create([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'slug' => 'before-update',
+    ]);
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->patchJson("/api/projects/{$project->id}/task-statuses/{$status->id}", [
+        'name' => 'After Update',
+        'slug' => 'after-update',
+        'position' => 4,
+    ])
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Task status updated successfully',
+            'data' => [
+                'id' => $status->id,
+                'workspace_id' => $workspace->id,
+                'project_id' => $project->id,
+                'name' => 'After Update',
+                'slug' => 'after-update',
+                'position' => 4,
+            ],
+        ]);
+
+    $this->assertDatabaseHas('task_statuses', [
+        'id' => $status->id,
+        'name' => 'After Update',
+        'slug' => 'after-update',
+        'position' => 4,
+    ]);
+});
+
+it('forbids updating an inaccessible task status', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-update-forbidden@example.com',
+    ]);
+    [, $accessibleProject] = taskStatusEndpointProjectForUser($user);
+    $hiddenStatus = TaskStatus::factory()->create([
+        'name' => 'Do Not Touch',
+    ]);
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->patchJson("/api/projects/{$accessibleProject->id}/task-statuses/{$hiddenStatus->id}", [
+        'name' => 'Changed Anyway',
+    ])
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Task status access denied',
+        ]);
+
+    $this->assertDatabaseHas('task_statuses', [
+        'id' => $hiddenStatus->id,
+        'name' => 'Do Not Touch',
+    ]);
+});
+
+it('soft deletes an accessible task status', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-delete@example.com',
+    ]);
+    [$workspace, $project] = taskStatusEndpointProjectForUser($user);
+    $status = TaskStatus::factory()->create([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+    ]);
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->deleteJson("/api/projects/{$project->id}/task-statuses/{$status->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Task status deleted successfully',
+            'data' => null,
+        ]);
+
+    $this->assertSoftDeleted('task_statuses', [
+        'id' => $status->id,
+    ]);
+});
+
+it('forbids deleting an inaccessible task status', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-delete-forbidden@example.com',
+    ]);
+    [, $accessibleProject] = taskStatusEndpointProjectForUser($user);
+    $hiddenStatus = TaskStatus::factory()->create();
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->deleteJson("/api/projects/{$accessibleProject->id}/task-statuses/{$hiddenStatus->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Task status access denied',
+        ]);
+
+    $this->assertNotSoftDeleted('task_statuses', [
+        'id' => $hiddenStatus->id,
+    ]);
+});
+
+function taskStatusEndpointLoginAs(User $user): void
+{
+    test()->postJson('/api/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertOk();
+}
+
+/**
+ * @return array{Workspace, Project}
+ */
+function taskStatusEndpointProjectForUser(User $user): array
+{
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+    $project = Project::factory()->create([
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'created_by' => $user->id,
+    ]);
+
+    $team->users()->attach($user->id);
+
+    return [$workspace, $project];
+}


### PR DESCRIPTION
## Summary

- Implemented authenticated task status API endpoints.
- Added task status create, list, show, update, and soft-delete behavior.
- Added task status validation through Form Requests.
- Added project-scoped task status access checks.
- Added task status feature tests.

## What changed

Task statuses can now be managed through protected API routes under projects.

Users can manage task statuses only for accessible projects. Task status slugs are validated within the existing database scope, and `workspace_id` is derived from the parent project.

## Testing

- Backend test suite passed with Pest.

## Notes

- No frontend work was added.
- No drag-and-drop ordering was added.
- No workflow automation was implemented.
- No Phase 4 permission matrix logic was implemented.