### PR TITLE
Merge backend domain API milestone into main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,9 @@ The project is built as a portfolio application focused on:
 - Next.js frontend architecture
 - MySQL database design
 - role-based and permission-based authorization
-- team/project/task workflows
+- team, project, task, and comment workflows
 - Dockerized local development
-- testing
+- backend testing
 - technical documentation
 - AI-assisted development workflow
 
@@ -25,81 +25,70 @@ The project is built as a portfolio application focused on:
 - `docker-compose.yml` — local development services
 - `README.md` — main project overview and setup entry point
 
-## Current Phase Status
+## Current Project Status
 
-Phase 1 backend foundation is complete.
+The Laravel API has implemented authentication and core domain APIs.
 
-Implemented backend foundation includes:
+Current backend behavior should be verified from the code and documentation, especially:
 
-- Laravel API route foundation
-- `GET /api/health`
-- `App\Support\ApiResponse`
-- core database migrations
-- Eloquent models and relationships
-- factories
-- seeders
-- Pest setup
-- backend smoke tests
-- Phase 1 documentation
+- `apps/api/AGENTS.md`
+- `apps/api/routes/api.php`
+- `docs/architecture.md`
+- `docs/auth.md`
+- `docs/database.md`
+- `docs/testing.md`
 
-Not implemented yet:
-
-- authentication
-- Laravel Sanctum login/logout flow
-- controllers for domain resources
-- form requests
-- API resources
-- policies
-- permission enforcement
-- frontend dashboard workflows
-
-Do not assume these planned pieces already exist.
+Do not assume planned features exist unless the code or documentation confirms them.
 
 ## General Rules
 
 - Inspect existing files before editing.
 - Only edit files relevant to the requested task.
-- Do not make broad architectural changes unless explicitly requested.
-- Do not add new packages unless explicitly requested.
-- Do not rename existing files, classes, branches, tables, or routes unless explicitly requested.
+- Keep changes small and focused.
 - Prefer simple, readable code over clever abstractions.
 - Preserve existing project conventions.
-- Keep changes small and focused.
+- Do not add packages unless explicitly requested.
+- Do not rename files, classes, routes, route parameters, tables, columns, or branches unless explicitly requested.
+- Do not make broad architectural changes unless explicitly requested.
+- Do not use planning labels in production filenames, test filenames, class names, helper names, or route names.
 - Do not commit changes unless explicitly asked.
-- Ask for clarification when a task is ambiguous instead of guessing.
 
 ## Documentation Rules
 
-When changing architecture, update:
+Update documentation when changing:
 
-- `docs/architecture.md`
+- architecture
+- setup or Docker workflow
+- database structure
+- authentication behavior
+- authorization behavior
+- testing setup or testing strategy
+- public API behavior
 
-When changing database structure, update:
-
-- `docs/database.md`
-
-When changing setup or Docker workflow, update:
+Relevant documentation locations include:
 
 - `README.md`
-- `docs/setup.md`
-
-When changing testing setup or test strategy, update:
-
+- `docs/architecture.md`
+- `docs/auth.md`
+- `docs/database.md`
 - `docs/testing.md`
-
-When changing permissions or authorization rules, update:
-
 - `docs/permissions.md`
 
-Do not invent implemented features in documentation. If something is planned but not built, label it as planned.
+Do not invent implemented features in documentation.
+
+If something is planned but not built, label it as planned.
 
 ## Backend Rules
 
-Laravel backend lives in:
+Laravel backend code lives in:
 
 - `apps/api`
 
-Run Laravel, Composer, and Pest commands inside the API container.
+Backend-specific instructions live in:
+
+- `apps/api/AGENTS.md`
+
+Run Laravel, Composer, Artisan, and Pest commands inside the API container.
 
 Use:
 
@@ -111,50 +100,13 @@ docker compose exec api ./vendor/bin/pest
 
 Do not assume host PHP or host Composer is the runtime source of truth.
 
-## Laravel Code Rules
-
-- Keep controllers thin.
-- Use Form Request classes for validation when request validation is introduced.
-- Use API Resources for structured resource responses when domain endpoints are introduced.
-- Use Policies/Gates for authorization when permissions are introduced.
-- Do not put complex business logic in controllers.
-- Do not duplicate response formatting manually when `App\Support\ApiResponse` fits the task.
-- Do not implement frontend-only security.
-- Backend authorization must be enforced server-side.
-
-## Database Rules
-
-- Do not edit already-merged migrations unless explicitly requested.
-- For schema changes after merge, create a new migration.
-- Keep workspace scoping in mind.
-- Roles are workspace-scoped.
-- Permissions are global permission definitions.
-- Team/user/role assignment is represented through `team_user_role`.
-- Do not add soft deletes to pivot tables unless explicitly requested.
-
-## Testing Rules
-
-Before finishing backend work, run:
-
-```bash
-docker compose exec api ./vendor/bin/pest
-```
-
-Current smoke tests cover:
-
-- API health endpoint
-- basic factory/database persistence
-- demo seeders
-
-Do not claim auth, permission, policy, controller, or business workflow coverage until those tests exist.
-
 ## Frontend Rules
 
-Frontend lives in:
+Frontend code lives in:
 
 - `apps/web`
 
-Planned frontend stack:
+Expected frontend stack:
 
 - Next.js
 - TypeScript
@@ -163,9 +115,39 @@ Planned frontend stack:
 - React Hook Form
 - Zod
 
-Use Next.js App Router. Do not add React Router.
+Use Next.js App Router.
 
-Frontend permission checks are only for user experience. They are not security.
+Do not add React Router.
+
+Frontend permission checks are only user experience helpers. They are not security.
+
+## Authorization Rules
+
+Backend authorization must be enforced server-side.
+
+Frontend-only permission checks are not sufficient.
+
+Do not add broad role or permission architecture unless explicitly requested.
+
+Do not claim authorization, permission, or policy coverage unless matching tests exist.
+
+## Testing Rules
+
+Backend tests use Pest.
+
+Before finishing backend work, run:
+
+```bash
+docker compose exec api ./vendor/bin/pest
+```
+
+When route behavior changes, also run:
+
+```bash
+docker compose exec api php artisan route:list
+```
+
+Do not claim test coverage unless matching tests exist.
 
 ## Docker Rules
 
@@ -183,26 +165,17 @@ docker compose exec api php artisan migrate:fresh --seed
 docker compose exec api ./vendor/bin/pest
 ```
 
-The API service uses:
+The API service uses bind-mounted source code and a Docker volume for Composer dependencies.
 
-```yaml
-./apps/api:/var/www/html
-api_vendor:/var/www/html/vendor
-```
-
-Meaning:
-
-- Laravel source code is bind-mounted from the host.
-- Composer dependencies live in a Docker named volume.
-- Run Composer inside the container, not on the host.
+Run Composer inside the container, not on the host.
 
 ## Git Rules
 
 Use small, focused branches.
 
-Branch examples:
+Example branch names:
 
-```
+```txt
 feature/auth-login
 feature/team-management
 feature/task-comments
@@ -213,7 +186,7 @@ test/auth-feature-tests
 
 Use conventional commits:
 
-```
+```txt
 feat: add login endpoint
 fix: correct role permission pivot
 docs: update setup guide
@@ -229,4 +202,3 @@ After editing, summarize:
 - files changed
 - what changed
 - commands run
-- remaining risks or follow-up work

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ viewer@demo.test
 
 ## Authentication
 
-Phase 2 backend authentication is implemented with Laravel Sanctum session authentication.
+Backend authentication is implemented with Laravel Sanctum session authentication.
 
 Implemented API auth includes registration, login, logout, `GET /api/me`, disabled-user handling, email verification, password reset, and auth feature tests.
 
@@ -221,6 +221,7 @@ See:
 ```txt
 docs/architecture.md
 docs/auth.md
+docs/domain-api.md
 docs/database.md
 docs/testing.md
 docs/setup.md
@@ -231,7 +232,7 @@ docs/ai-rules.md
 
 ## Current Status
 
-Phase 1 backend foundation and Phase 2 backend authentication are complete.
+The Laravel API has implemented authentication and the core domain API.
 
 Implemented:
 
@@ -239,14 +240,18 @@ Implemented:
 - Shared API response helper
 - Laravel Sanctum session authentication
 - Registration, login, logout, current user, email verification, password reset, and disabled-user auth handling
+- Workspace, team, team member, project, project member, task status, task, and comment endpoints
+- Membership-based domain access checks for protected resources
+- Author-only comment update and delete checks
 - Core Eloquent models and relationships
 - Database migrations for users, workspaces, teams, projects, tasks, comments, roles, permissions, statuses, and pivots
 - Factories and seeders for backend smoke data
-- Pest tests for health, database factories, seeders, and auth behavior
+- Pest tests for health, database factories, seeders, auth behavior, domain endpoints, membership endpoints, comments, and domain authorization
 
 Planned later:
 
 - Frontend auth pages
-- Team/project/task CRUD
-- Policies and backend permission enforcement
+- Frontend team/project/task workflows
+- Role and permission matrix enforcement
+- Policies, gates, and permission services
 - Frontend application workflows

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -4,45 +4,110 @@
 
 This file applies to Laravel API work in `apps/api`.
 
-Phase 2 backend scope is authentication only:
+The root repository instructions in `../../AGENTS.md` also apply.
 
-- Laravel Sanctum login/logout flow
-- `GET /api/me` authenticated user endpoint
-- backend validation, responses, authorization checks, and tests for auth
+## Current API Status
 
-Out of scope for Phase 2:
+The Laravel API currently includes:
 
-- frontend work
-- team/project/task CRUD
-- admin dashboard
-- unrelated refactors
+- health endpoint
+- shared API response helper
+- Sanctum authentication
+- register, login, logout, authenticated user, email verification, and password reset endpoints
+- disabled-user access blocking
+- workspace endpoints
+- team endpoints
+- team membership endpoints
+- project endpoints
+- project membership endpoints
+- task status endpoints
+- task endpoints
+- comment endpoints
+- domain authorization feature tests
+
+Do not assume planned behavior exists unless the code or documentation confirms it.
+
+## Access Model
+
+Current protected routes use:
+
+- `auth:sanctum`
+- `not.disabled`
+
+Current domain access rules:
+
+- Workspaces are the top-level domain scope.
+- A user can access a workspace when they belong to at least one team inside that workspace.
+- Teams belong to workspaces.
+- Projects belong to workspaces.
+- Task statuses belong to projects.
+- Tasks belong to projects.
+- Comments belong to tasks.
+- Nested route access must verify both user access and parent-child ownership.
+- Comment update and delete are author-only.
+- Team membership is managed through `team_user`.
+- Project membership is managed through `project_user`.
+- The `team_user_role` pivot is reserved for role assignment work and must not be used for basic membership endpoints.
+- Full role and permission matrix enforcement is planned but not implemented yet.
 
 ## Laravel API Conventions
 
 - Keep controllers thin.
-- Put request validation in Form Request classes when validation is introduced.
+- Put request validation in Form Request classes.
+- Use API Resources for structured resource responses.
 - Use `App\Support\ApiResponse` for consistent JSON responses when it fits the task.
-- Use API Resources where structured response transformation is useful.
 - Keep business logic out of controllers when it grows beyond simple orchestration.
 - Preserve existing namespaces, route style, model names, and project conventions.
+- Do not rename routes, route parameters, models, tables, or columns unless explicitly requested.
+- Do not use planning labels in production filenames, test filenames, class names, helper names, or route names.
+- Do not add broad service layers, policies, gates, or permission abstractions unless explicitly requested.
 
-## Authentication And Permissions
+## Authentication And Authorization
 
-- Do not assume auth, policies, gates, or permission enforcement already exist unless the code shows they do.
-- Enforce authorization on the backend. Frontend checks are only user experience helpers.
-- Any auth or permission behavior change must include relevant Pest tests.
-- Do not add broad permission architecture unless explicitly requested.
+- Enforce authorization on the backend.
+- Frontend checks are only user experience helpers.
+- Any authentication or authorization behavior change must include relevant Pest tests.
+- Do not implement role hierarchy or permission matrix behavior unless the task specifically asks for it.
+- Keep current access rules simple and explicit until the permission system is implemented.
+- Do not claim authentication, authorization, permission, policy, or workflow coverage unless matching tests exist.
+
+## Validation And Responses
+
+- Use Form Requests for request validation.
+- Keep validation aligned with the current database schema.
+- Do not invent request fields that are not supported by the schema.
+- Prefer server-controlled values for ownership/scope fields such as `workspace_id`, `created_by`, and authenticated `user_id`.
+- Use API Resources for response serialization.
+- Do not expose sensitive user fields such as passwords, remember tokens, disabled status, permissions, or internal role data unless explicitly required.
+
+## Database Rules
+
+- Do not edit already-merged migrations unless explicitly requested.
+- For schema changes after merge, create a new migration.
+- Keep workspace scoping in mind.
+- Do not add soft deletes to pivot tables unless explicitly requested.
+- Do not use `team_user_role` for basic membership behavior.
+- Validate nested resources against their parent scope.
 
 ## Testing
 
-- Backend tests use Pest.
-- Add focused feature or unit tests for new backend behavior.
-- Do not claim auth, permission, policy, or workflow coverage unless matching tests exist.
-- Before finishing backend work, run:
+Backend tests use Pest.
+
+Add focused feature or unit tests for new backend behavior.
+
+Before finishing backend work, run:
 
 ```bash
 docker compose exec api ./vendor/bin/pest
 ```
+
+When routes are added or changed, run:
+
+```bash
+docker compose exec api php artisan route:list
+```
+
+Do not claim test coverage unless matching tests exist.
 
 ## Docker Commands
 

--- a/apps/api/app/Http/Controllers/Api/CommentController.php
+++ b/apps/api/app/Http/Controllers/Api/CommentController.php
@@ -5,38 +5,153 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Domain\StoreCommentRequest;
 use App\Http\Requests\Domain\UpdateCommentRequest;
+use App\Http\Resources\CommentResource;
+use App\Models\Comment;
+use App\Models\Task;
 use App\Support\ApiResponse;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 class CommentController extends Controller
 {
-    public function index(string $task): JsonResponse
+    public function index(Request $request, string $task): JsonResponse
     {
-        return $this->placeholder('Comment index endpoint is not implemented yet');
+        $task = $this->accessibleTask($request, $task);
+
+        if (! $task) {
+            return $this->forbidden();
+        }
+
+        $comments = $task->comments()
+            ->with('user')
+            ->orderBy('created_at')
+            ->get();
+
+        return ApiResponse::success(
+            CommentResource::collection($comments),
+            'Comments retrieved successfully'
+        );
     }
 
     public function store(StoreCommentRequest $request, string $task): JsonResponse
     {
-        return $this->placeholder('Comment store endpoint is not implemented yet');
+        $task = $this->accessibleTask($request, $task);
+
+        if (! $task) {
+            return $this->forbidden();
+        }
+
+        $comment = $task->comments()->create([
+            ...$request->validated(),
+            'user_id' => $request->user()->id,
+        ]);
+
+        return ApiResponse::success(
+            new CommentResource($comment->load('user')),
+            'Comment created successfully',
+            201
+        );
     }
 
-    public function show(string $task, string $comment): JsonResponse
+    public function show(Request $request, string $task, string $comment): JsonResponse
     {
-        return $this->placeholder('Comment show endpoint is not implemented yet');
+        $comment = $this->accessibleComment($request, $task, $comment);
+
+        if (! $comment) {
+            return $this->forbidden();
+        }
+
+        return ApiResponse::success(
+            new CommentResource($comment->load('user')),
+            'Comment retrieved successfully'
+        );
     }
 
     public function update(UpdateCommentRequest $request, string $task, string $comment): JsonResponse
     {
-        return $this->placeholder('Comment update endpoint is not implemented yet');
+        $comment = $this->accessibleComment($request, $task, $comment);
+
+        if (! $comment) {
+            return $this->forbidden();
+        }
+
+        if (! $this->isAuthor($request, $comment)) {
+            return $this->authorForbidden();
+        }
+
+        $comment->update($request->validated());
+
+        return ApiResponse::success(
+            new CommentResource($comment->load('user')),
+            'Comment updated successfully'
+        );
     }
 
-    public function destroy(string $task, string $comment): JsonResponse
+    public function destroy(Request $request, string $task, string $comment): JsonResponse
     {
-        return $this->placeholder('Comment destroy endpoint is not implemented yet');
+        $comment = $this->accessibleComment($request, $task, $comment);
+
+        if (! $comment) {
+            return $this->forbidden();
+        }
+
+        if (! $this->isAuthor($request, $comment)) {
+            return $this->authorForbidden();
+        }
+
+        $comment->delete();
+
+        return ApiResponse::success(
+            null,
+            'Comment deleted successfully'
+        );
     }
 
-    private function placeholder(string $message): JsonResponse
+    private function accessibleTask(Request $request, string $task): ?Task
     {
-        return ApiResponse::error($message, [], 501);
+        return Task::query()
+            ->whereKey($task)
+            ->whereHas('project.workspace.teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function accessibleComment(Request $request, string $task, string $comment): ?Comment
+    {
+        return Comment::query()
+            ->whereKey($comment)
+            ->where('task_id', $task)
+            ->whereHas('task.project.workspace.teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function isAuthor(Request $request, Comment $comment): bool
+    {
+        return $comment->user_id === $request->user()->id;
+    }
+
+    private function forbidden(): JsonResponse
+    {
+        return ApiResponse::error(
+            'Comment access denied',
+            [
+                'comment' => ['You do not have access to this comment.'],
+            ],
+            403
+        );
+    }
+
+    private function authorForbidden(): JsonResponse
+    {
+        return ApiResponse::error(
+            'Comment author required',
+            [
+                'comment' => ['Only the comment author can modify this comment.'],
+            ],
+            403
+        );
     }
 }

--- a/apps/api/app/Http/Controllers/Api/CommentController.php
+++ b/apps/api/app/Http/Controllers/Api/CommentController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreCommentRequest;
+use App\Http\Requests\Domain\UpdateCommentRequest;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+
+class CommentController extends Controller
+{
+    public function index(string $task): JsonResponse
+    {
+        return $this->placeholder('Comment index endpoint is not implemented yet');
+    }
+
+    public function store(StoreCommentRequest $request, string $task): JsonResponse
+    {
+        return $this->placeholder('Comment store endpoint is not implemented yet');
+    }
+
+    public function show(string $task, string $comment): JsonResponse
+    {
+        return $this->placeholder('Comment show endpoint is not implemented yet');
+    }
+
+    public function update(UpdateCommentRequest $request, string $task, string $comment): JsonResponse
+    {
+        return $this->placeholder('Comment update endpoint is not implemented yet');
+    }
+
+    public function destroy(string $task, string $comment): JsonResponse
+    {
+        return $this->placeholder('Comment destroy endpoint is not implemented yet');
+    }
+
+    private function placeholder(string $message): JsonResponse
+    {
+        return ApiResponse::error($message, [], 501);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/ProjectController.php
+++ b/apps/api/app/Http/Controllers/Api/ProjectController.php
@@ -5,38 +5,128 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Domain\StoreProjectRequest;
 use App\Http\Requests\Domain\UpdateProjectRequest;
+use App\Http\Resources\ProjectResource;
+use App\Models\Project;
+use App\Models\Workspace;
 use App\Support\ApiResponse;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 class ProjectController extends Controller
 {
-    public function index(string $workspace): JsonResponse
+    public function index(Request $request, string $workspace): JsonResponse
     {
-        return $this->placeholder('Project index endpoint is not implemented yet');
+        $workspace = $this->accessibleWorkspace($request, $workspace);
+
+        if (! $workspace) {
+            return $this->forbidden();
+        }
+
+        $projects = $workspace->projects()
+            ->orderBy('name')
+            ->get();
+
+        return ApiResponse::success(
+            ProjectResource::collection($projects),
+            'Projects retrieved successfully'
+        );
     }
 
     public function store(StoreProjectRequest $request, string $workspace): JsonResponse
     {
-        return $this->placeholder('Project store endpoint is not implemented yet');
+        $workspace = $this->accessibleWorkspace($request, $workspace);
+
+        if (! $workspace) {
+            return $this->forbidden();
+        }
+
+        $project = $workspace->projects()->create([
+            ...$request->validated(),
+            'created_by' => $request->user()->id,
+        ]);
+
+        return ApiResponse::success(
+            new ProjectResource($project),
+            'Project created successfully',
+            201
+        );
     }
 
-    public function show(string $workspace, string $project): JsonResponse
+    public function show(Request $request, string $workspace, string $project): JsonResponse
     {
-        return $this->placeholder('Project show endpoint is not implemented yet');
+        $project = $this->accessibleProject($request, $workspace, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        return ApiResponse::success(
+            new ProjectResource($project),
+            'Project retrieved successfully'
+        );
     }
 
     public function update(UpdateProjectRequest $request, string $workspace, string $project): JsonResponse
     {
-        return $this->placeholder('Project update endpoint is not implemented yet');
+        $project = $this->accessibleProject($request, $workspace, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $project->update($request->validated());
+
+        return ApiResponse::success(
+            new ProjectResource($project),
+            'Project updated successfully'
+        );
     }
 
-    public function destroy(string $workspace, string $project): JsonResponse
+    public function destroy(Request $request, string $workspace, string $project): JsonResponse
     {
-        return $this->placeholder('Project destroy endpoint is not implemented yet');
+        $project = $this->accessibleProject($request, $workspace, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $project->delete();
+
+        return ApiResponse::success(
+            null,
+            'Project deleted successfully'
+        );
     }
 
-    private function placeholder(string $message): JsonResponse
+    private function accessibleWorkspace(Request $request, string $workspace): ?Workspace
     {
-        return ApiResponse::error($message, [], 501);
+        return Workspace::query()
+            ->whereKey($workspace)
+            ->whereHas('teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function accessibleProject(Request $request, string $workspace, string $project): ?Project
+    {
+        return Project::query()
+            ->whereKey($project)
+            ->where('workspace_id', $workspace)
+            ->whereHas('workspace.teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function forbidden(): JsonResponse
+    {
+        return ApiResponse::error(
+            'Project access denied',
+            [
+                'project' => ['You do not have access to this project.'],
+            ],
+            403
+        );
     }
 }

--- a/apps/api/app/Http/Controllers/Api/ProjectController.php
+++ b/apps/api/app/Http/Controllers/Api/ProjectController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreProjectRequest;
+use App\Http\Requests\Domain\UpdateProjectRequest;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+
+class ProjectController extends Controller
+{
+    public function index(string $workspace): JsonResponse
+    {
+        return $this->placeholder('Project index endpoint is not implemented yet');
+    }
+
+    public function store(StoreProjectRequest $request, string $workspace): JsonResponse
+    {
+        return $this->placeholder('Project store endpoint is not implemented yet');
+    }
+
+    public function show(string $workspace, string $project): JsonResponse
+    {
+        return $this->placeholder('Project show endpoint is not implemented yet');
+    }
+
+    public function update(UpdateProjectRequest $request, string $workspace, string $project): JsonResponse
+    {
+        return $this->placeholder('Project update endpoint is not implemented yet');
+    }
+
+    public function destroy(string $workspace, string $project): JsonResponse
+    {
+        return $this->placeholder('Project destroy endpoint is not implemented yet');
+    }
+
+    private function placeholder(string $message): JsonResponse
+    {
+        return ApiResponse::error($message, [], 501);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/ProjectMemberController.php
+++ b/apps/api/app/Http/Controllers/Api/ProjectMemberController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreProjectMemberRequest;
+use App\Http\Resources\UserResource;
+use App\Models\Project;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ProjectMemberController extends Controller
+{
+    public function index(Request $request, string $workspace, string $project): JsonResponse
+    {
+        $project = $this->accessibleProject($request, $workspace, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $members = $project->users()
+            ->orderBy('name')
+            ->get();
+
+        return ApiResponse::success(
+            UserResource::collection($members),
+            'Project members retrieved successfully'
+        );
+    }
+
+    public function store(StoreProjectMemberRequest $request, string $workspace, string $project): JsonResponse
+    {
+        $project = $this->accessibleProject($request, $workspace, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $project->users()->attach($request->validated('user_id'));
+
+        $member = $project->users()
+            ->whereKey($request->validated('user_id'))
+            ->firstOrFail();
+
+        return ApiResponse::success(
+            new UserResource($member),
+            'Project member added successfully',
+            201
+        );
+    }
+
+    public function destroy(Request $request, string $workspace, string $project, string $user): JsonResponse
+    {
+        $project = $this->accessibleProject($request, $workspace, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $project->users()->detach($user);
+
+        return ApiResponse::success(
+            null,
+            'Project member removed successfully'
+        );
+    }
+
+    private function accessibleProject(Request $request, string $workspace, string $project): ?Project
+    {
+        return Project::query()
+            ->whereKey($project)
+            ->where('workspace_id', $workspace)
+            ->whereHas('workspace.teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function forbidden(): JsonResponse
+    {
+        return ApiResponse::error(
+            'Project access denied',
+            [
+                'project' => ['You do not have access to this project.'],
+            ],
+            403
+        );
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/TaskController.php
+++ b/apps/api/app/Http/Controllers/Api/TaskController.php
@@ -5,38 +5,128 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Domain\StoreTaskRequest;
 use App\Http\Requests\Domain\UpdateTaskRequest;
+use App\Http\Resources\TaskResource;
+use App\Models\Project;
+use App\Models\Task;
 use App\Support\ApiResponse;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 class TaskController extends Controller
 {
-    public function index(string $project): JsonResponse
+    public function index(Request $request, string $project): JsonResponse
     {
-        return $this->placeholder('Task index endpoint is not implemented yet');
+        $project = $this->accessibleProject($request, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $tasks = $project->tasks()
+            ->orderByDesc('created_at')
+            ->get();
+
+        return ApiResponse::success(
+            TaskResource::collection($tasks),
+            'Tasks retrieved successfully'
+        );
     }
 
     public function store(StoreTaskRequest $request, string $project): JsonResponse
     {
-        return $this->placeholder('Task store endpoint is not implemented yet');
+        $project = $this->accessibleProject($request, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $task = $project->tasks()->create([
+            ...$request->validated(),
+            'created_by' => $request->user()->id,
+        ]);
+
+        return ApiResponse::success(
+            new TaskResource($task),
+            'Task created successfully',
+            201
+        );
     }
 
-    public function show(string $project, string $task): JsonResponse
+    public function show(Request $request, string $project, string $task): JsonResponse
     {
-        return $this->placeholder('Task show endpoint is not implemented yet');
+        $task = $this->accessibleTask($request, $project, $task);
+
+        if (! $task) {
+            return $this->forbidden();
+        }
+
+        return ApiResponse::success(
+            new TaskResource($task),
+            'Task retrieved successfully'
+        );
     }
 
     public function update(UpdateTaskRequest $request, string $project, string $task): JsonResponse
     {
-        return $this->placeholder('Task update endpoint is not implemented yet');
+        $task = $this->accessibleTask($request, $project, $task);
+
+        if (! $task) {
+            return $this->forbidden();
+        }
+
+        $task->update($request->validated());
+
+        return ApiResponse::success(
+            new TaskResource($task),
+            'Task updated successfully'
+        );
     }
 
-    public function destroy(string $project, string $task): JsonResponse
+    public function destroy(Request $request, string $project, string $task): JsonResponse
     {
-        return $this->placeholder('Task destroy endpoint is not implemented yet');
+        $task = $this->accessibleTask($request, $project, $task);
+
+        if (! $task) {
+            return $this->forbidden();
+        }
+
+        $task->delete();
+
+        return ApiResponse::success(
+            null,
+            'Task deleted successfully'
+        );
     }
 
-    private function placeholder(string $message): JsonResponse
+    private function accessibleProject(Request $request, string $project): ?Project
     {
-        return ApiResponse::error($message, [], 501);
+        return Project::query()
+            ->whereKey($project)
+            ->whereHas('workspace.teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function accessibleTask(Request $request, string $project, string $task): ?Task
+    {
+        return Task::query()
+            ->whereKey($task)
+            ->where('project_id', $project)
+            ->whereHas('project.workspace.teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function forbidden(): JsonResponse
+    {
+        return ApiResponse::error(
+            'Task access denied',
+            [
+                'task' => ['You do not have access to this task.'],
+            ],
+            403
+        );
     }
 }

--- a/apps/api/app/Http/Controllers/Api/TaskController.php
+++ b/apps/api/app/Http/Controllers/Api/TaskController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreTaskRequest;
+use App\Http\Requests\Domain\UpdateTaskRequest;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+
+class TaskController extends Controller
+{
+    public function index(string $project): JsonResponse
+    {
+        return $this->placeholder('Task index endpoint is not implemented yet');
+    }
+
+    public function store(StoreTaskRequest $request, string $project): JsonResponse
+    {
+        return $this->placeholder('Task store endpoint is not implemented yet');
+    }
+
+    public function show(string $project, string $task): JsonResponse
+    {
+        return $this->placeholder('Task show endpoint is not implemented yet');
+    }
+
+    public function update(UpdateTaskRequest $request, string $project, string $task): JsonResponse
+    {
+        return $this->placeholder('Task update endpoint is not implemented yet');
+    }
+
+    public function destroy(string $project, string $task): JsonResponse
+    {
+        return $this->placeholder('Task destroy endpoint is not implemented yet');
+    }
+
+    private function placeholder(string $message): JsonResponse
+    {
+        return ApiResponse::error($message, [], 501);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/TaskStatusController.php
+++ b/apps/api/app/Http/Controllers/Api/TaskStatusController.php
@@ -5,38 +5,129 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Domain\StoreTaskStatusRequest;
 use App\Http\Requests\Domain\UpdateTaskStatusRequest;
+use App\Http\Resources\TaskStatusResource;
+use App\Models\Project;
+use App\Models\TaskStatus;
 use App\Support\ApiResponse;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 class TaskStatusController extends Controller
 {
-    public function index(string $project): JsonResponse
+    public function index(Request $request, string $project): JsonResponse
     {
-        return $this->placeholder('Task status index endpoint is not implemented yet');
+        $project = $this->accessibleProject($request, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $statuses = $project->taskStatuses()
+            ->orderBy('position')
+            ->orderBy('name')
+            ->get();
+
+        return ApiResponse::success(
+            TaskStatusResource::collection($statuses),
+            'Task statuses retrieved successfully'
+        );
     }
 
     public function store(StoreTaskStatusRequest $request, string $project): JsonResponse
     {
-        return $this->placeholder('Task status store endpoint is not implemented yet');
+        $project = $this->accessibleProject($request, $project);
+
+        if (! $project) {
+            return $this->forbidden();
+        }
+
+        $status = $project->taskStatuses()->create([
+            ...$request->validated(),
+            'workspace_id' => $project->workspace_id,
+        ]);
+
+        return ApiResponse::success(
+            new TaskStatusResource($status),
+            'Task status created successfully',
+            201
+        );
     }
 
-    public function show(string $project, string $taskStatus): JsonResponse
+    public function show(Request $request, string $project, string $taskStatus): JsonResponse
     {
-        return $this->placeholder('Task status show endpoint is not implemented yet');
+        $status = $this->accessibleTaskStatus($request, $project, $taskStatus);
+
+        if (! $status) {
+            return $this->forbidden();
+        }
+
+        return ApiResponse::success(
+            new TaskStatusResource($status),
+            'Task status retrieved successfully'
+        );
     }
 
     public function update(UpdateTaskStatusRequest $request, string $project, string $taskStatus): JsonResponse
     {
-        return $this->placeholder('Task status update endpoint is not implemented yet');
+        $status = $this->accessibleTaskStatus($request, $project, $taskStatus);
+
+        if (! $status) {
+            return $this->forbidden();
+        }
+
+        $status->update($request->validated());
+
+        return ApiResponse::success(
+            new TaskStatusResource($status),
+            'Task status updated successfully'
+        );
     }
 
-    public function destroy(string $project, string $taskStatus): JsonResponse
+    public function destroy(Request $request, string $project, string $taskStatus): JsonResponse
     {
-        return $this->placeholder('Task status destroy endpoint is not implemented yet');
+        $status = $this->accessibleTaskStatus($request, $project, $taskStatus);
+
+        if (! $status) {
+            return $this->forbidden();
+        }
+
+        $status->delete();
+
+        return ApiResponse::success(
+            null,
+            'Task status deleted successfully'
+        );
     }
 
-    private function placeholder(string $message): JsonResponse
+    private function accessibleProject(Request $request, string $project): ?Project
     {
-        return ApiResponse::error($message, [], 501);
+        return Project::query()
+            ->whereKey($project)
+            ->whereHas('workspace.teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function accessibleTaskStatus(Request $request, string $project, string $taskStatus): ?TaskStatus
+    {
+        return TaskStatus::query()
+            ->whereKey($taskStatus)
+            ->where('project_id', $project)
+            ->whereHas('project.workspace.teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function forbidden(): JsonResponse
+    {
+        return ApiResponse::error(
+            'Task status access denied',
+            [
+                'task_status' => ['You do not have access to this task status.'],
+            ],
+            403
+        );
     }
 }

--- a/apps/api/app/Http/Controllers/Api/TaskStatusController.php
+++ b/apps/api/app/Http/Controllers/Api/TaskStatusController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreTaskStatusRequest;
+use App\Http\Requests\Domain\UpdateTaskStatusRequest;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+
+class TaskStatusController extends Controller
+{
+    public function index(string $project): JsonResponse
+    {
+        return $this->placeholder('Task status index endpoint is not implemented yet');
+    }
+
+    public function store(StoreTaskStatusRequest $request, string $project): JsonResponse
+    {
+        return $this->placeholder('Task status store endpoint is not implemented yet');
+    }
+
+    public function show(string $project, string $taskStatus): JsonResponse
+    {
+        return $this->placeholder('Task status show endpoint is not implemented yet');
+    }
+
+    public function update(UpdateTaskStatusRequest $request, string $project, string $taskStatus): JsonResponse
+    {
+        return $this->placeholder('Task status update endpoint is not implemented yet');
+    }
+
+    public function destroy(string $project, string $taskStatus): JsonResponse
+    {
+        return $this->placeholder('Task status destroy endpoint is not implemented yet');
+    }
+
+    private function placeholder(string $message): JsonResponse
+    {
+        return ApiResponse::error($message, [], 501);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/TeamController.php
+++ b/apps/api/app/Http/Controllers/Api/TeamController.php
@@ -5,38 +5,125 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Domain\StoreTeamRequest;
 use App\Http\Requests\Domain\UpdateTeamRequest;
+use App\Http\Resources\TeamResource;
+use App\Models\Team;
+use App\Models\Workspace;
 use App\Support\ApiResponse;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 class TeamController extends Controller
 {
-    public function index(string $workspace): JsonResponse
+    public function index(Request $request, string $workspace): JsonResponse
     {
-        return $this->placeholder('Team index endpoint is not implemented yet');
+        $workspace = $this->accessibleWorkspace($request, $workspace);
+
+        if (! $workspace) {
+            return $this->forbidden();
+        }
+
+        $teams = $workspace->teams()
+            ->orderBy('name')
+            ->get();
+
+        return ApiResponse::success(
+            TeamResource::collection($teams),
+            'Teams retrieved successfully'
+        );
     }
 
     public function store(StoreTeamRequest $request, string $workspace): JsonResponse
     {
-        return $this->placeholder('Team store endpoint is not implemented yet');
+        $workspace = $this->accessibleWorkspace($request, $workspace);
+
+        if (! $workspace) {
+            return $this->forbidden();
+        }
+
+        $team = $workspace->teams()->create($request->validated());
+
+        return ApiResponse::success(
+            new TeamResource($team),
+            'Team created successfully',
+            201
+        );
     }
 
-    public function show(string $workspace, string $team): JsonResponse
+    public function show(Request $request, string $workspace, string $team): JsonResponse
     {
-        return $this->placeholder('Team show endpoint is not implemented yet');
+        $team = $this->accessibleTeam($request, $workspace, $team);
+
+        if (! $team) {
+            return $this->forbidden();
+        }
+
+        return ApiResponse::success(
+            new TeamResource($team),
+            'Team retrieved successfully'
+        );
     }
 
     public function update(UpdateTeamRequest $request, string $workspace, string $team): JsonResponse
     {
-        return $this->placeholder('Team update endpoint is not implemented yet');
+        $team = $this->accessibleTeam($request, $workspace, $team);
+
+        if (! $team) {
+            return $this->forbidden();
+        }
+
+        $team->update($request->validated());
+
+        return ApiResponse::success(
+            new TeamResource($team),
+            'Team updated successfully'
+        );
     }
 
-    public function destroy(string $workspace, string $team): JsonResponse
+    public function destroy(Request $request, string $workspace, string $team): JsonResponse
     {
-        return $this->placeholder('Team destroy endpoint is not implemented yet');
+        $team = $this->accessibleTeam($request, $workspace, $team);
+
+        if (! $team) {
+            return $this->forbidden();
+        }
+
+        $team->delete();
+
+        return ApiResponse::success(
+            null,
+            'Team deleted successfully'
+        );
     }
 
-    private function placeholder(string $message): JsonResponse
+    private function accessibleWorkspace(Request $request, string $workspace): ?Workspace
     {
-        return ApiResponse::error($message, [], 501);
+        return Workspace::query()
+            ->whereKey($workspace)
+            ->whereHas('teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function accessibleTeam(Request $request, string $workspace, string $team): ?Team
+    {
+        return Team::query()
+            ->whereKey($team)
+            ->where('workspace_id', $workspace)
+            ->whereHas('workspace.teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function forbidden(): JsonResponse
+    {
+        return ApiResponse::error(
+            'Team access denied',
+            [
+                'team' => ['You do not have access to this team.'],
+            ],
+            403
+        );
     }
 }

--- a/apps/api/app/Http/Controllers/Api/TeamController.php
+++ b/apps/api/app/Http/Controllers/Api/TeamController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreTeamRequest;
+use App\Http\Requests\Domain\UpdateTeamRequest;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+
+class TeamController extends Controller
+{
+    public function index(string $workspace): JsonResponse
+    {
+        return $this->placeholder('Team index endpoint is not implemented yet');
+    }
+
+    public function store(StoreTeamRequest $request, string $workspace): JsonResponse
+    {
+        return $this->placeholder('Team store endpoint is not implemented yet');
+    }
+
+    public function show(string $workspace, string $team): JsonResponse
+    {
+        return $this->placeholder('Team show endpoint is not implemented yet');
+    }
+
+    public function update(UpdateTeamRequest $request, string $workspace, string $team): JsonResponse
+    {
+        return $this->placeholder('Team update endpoint is not implemented yet');
+    }
+
+    public function destroy(string $workspace, string $team): JsonResponse
+    {
+        return $this->placeholder('Team destroy endpoint is not implemented yet');
+    }
+
+    private function placeholder(string $message): JsonResponse
+    {
+        return ApiResponse::error($message, [], 501);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/TeamMemberController.php
+++ b/apps/api/app/Http/Controllers/Api/TeamMemberController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreTeamMemberRequest;
+use App\Http\Resources\UserResource;
+use App\Models\Team;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class TeamMemberController extends Controller
+{
+    public function index(Request $request, string $workspace, string $team): JsonResponse
+    {
+        $team = $this->accessibleTeam($request, $workspace, $team);
+
+        if (! $team) {
+            return $this->forbidden();
+        }
+
+        $members = $team->users()
+            ->orderBy('name')
+            ->get();
+
+        return ApiResponse::success(
+            UserResource::collection($members),
+            'Team members retrieved successfully'
+        );
+    }
+
+    public function store(StoreTeamMemberRequest $request, string $workspace, string $team): JsonResponse
+    {
+        $team = $this->accessibleTeam($request, $workspace, $team);
+
+        if (! $team) {
+            return $this->forbidden();
+        }
+
+        $team->users()->attach($request->validated('user_id'));
+
+        $member = $team->users()
+            ->whereKey($request->validated('user_id'))
+            ->firstOrFail();
+
+        return ApiResponse::success(
+            new UserResource($member),
+            'Team member added successfully',
+            201
+        );
+    }
+
+    public function destroy(Request $request, string $workspace, string $team, string $user): JsonResponse
+    {
+        $team = $this->accessibleTeam($request, $workspace, $team);
+
+        if (! $team) {
+            return $this->forbidden();
+        }
+
+        $team->users()->detach($user);
+
+        return ApiResponse::success(
+            null,
+            'Team member removed successfully'
+        );
+    }
+
+    private function accessibleTeam(Request $request, string $workspace, string $team): ?Team
+    {
+        return Team::query()
+            ->whereKey($team)
+            ->where('workspace_id', $workspace)
+            ->whereHas('workspace.teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function forbidden(): JsonResponse
+    {
+        return ApiResponse::error(
+            'Team access denied',
+            [
+                'team' => ['You do not have access to this team.'],
+            ],
+            403
+        );
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/WorkspaceController.php
+++ b/apps/api/app/Http/Controllers/Api/WorkspaceController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Domain\StoreWorkspaceRequest;
+use App\Http\Requests\Domain\UpdateWorkspaceRequest;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+
+class WorkspaceController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return $this->placeholder('Workspace index endpoint is not implemented yet');
+    }
+
+    public function store(StoreWorkspaceRequest $request): JsonResponse
+    {
+        return $this->placeholder('Workspace store endpoint is not implemented yet');
+    }
+
+    public function show(string $workspace): JsonResponse
+    {
+        return $this->placeholder('Workspace show endpoint is not implemented yet');
+    }
+
+    public function update(UpdateWorkspaceRequest $request, string $workspace): JsonResponse
+    {
+        return $this->placeholder('Workspace update endpoint is not implemented yet');
+    }
+
+    public function destroy(string $workspace): JsonResponse
+    {
+        return $this->placeholder('Workspace destroy endpoint is not implemented yet');
+    }
+
+    private function placeholder(string $message): JsonResponse
+    {
+        return ApiResponse::error($message, [], 501);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/WorkspaceController.php
+++ b/apps/api/app/Http/Controllers/Api/WorkspaceController.php
@@ -5,38 +5,117 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Domain\StoreWorkspaceRequest;
 use App\Http\Requests\Domain\UpdateWorkspaceRequest;
+use App\Http\Resources\WorkspaceResource;
+use App\Models\Workspace;
 use App\Support\ApiResponse;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class WorkspaceController extends Controller
 {
-    public function index(): JsonResponse
+    public function index(Request $request): JsonResponse
     {
-        return $this->placeholder('Workspace index endpoint is not implemented yet');
+        $workspaces = Workspace::query()
+            ->whereHas('teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->orderBy('name')
+            ->get();
+
+        return ApiResponse::success(
+            WorkspaceResource::collection($workspaces),
+            'Workspaces retrieved successfully'
+        );
     }
 
     public function store(StoreWorkspaceRequest $request): JsonResponse
     {
-        return $this->placeholder('Workspace store endpoint is not implemented yet');
+        $workspace = DB::transaction(function () use ($request): Workspace {
+            $workspace = Workspace::create($request->validated());
+
+            $team = $workspace->teams()->create([
+                'name' => 'Default Team',
+                'slug' => 'default-team',
+                'description' => 'Default team for workspace members.',
+            ]);
+
+            $team->users()->attach($request->user()->id);
+
+            return $workspace;
+        });
+
+        return ApiResponse::success(
+            new WorkspaceResource($workspace),
+            'Workspace created successfully',
+            201
+        );
     }
 
-    public function show(string $workspace): JsonResponse
+    public function show(Request $request, string $workspace): JsonResponse
     {
-        return $this->placeholder('Workspace show endpoint is not implemented yet');
+        $workspace = $this->accessibleWorkspace($request, $workspace);
+
+        if (! $workspace) {
+            return $this->forbidden();
+        }
+
+        return ApiResponse::success(
+            new WorkspaceResource($workspace),
+            'Workspace retrieved successfully'
+        );
     }
 
     public function update(UpdateWorkspaceRequest $request, string $workspace): JsonResponse
     {
-        return $this->placeholder('Workspace update endpoint is not implemented yet');
+        $workspace = $this->accessibleWorkspace($request, $workspace);
+
+        if (! $workspace) {
+            return $this->forbidden();
+        }
+
+        $workspace->update($request->validated());
+
+        return ApiResponse::success(
+            new WorkspaceResource($workspace),
+            'Workspace updated successfully'
+        );
     }
 
-    public function destroy(string $workspace): JsonResponse
+    public function destroy(Request $request, string $workspace): JsonResponse
     {
-        return $this->placeholder('Workspace destroy endpoint is not implemented yet');
+        $workspace = $this->accessibleWorkspace($request, $workspace);
+
+        if (! $workspace) {
+            return $this->forbidden();
+        }
+
+        $workspace->delete();
+
+        return ApiResponse::success(
+            null,
+            'Workspace deleted successfully'
+        );
     }
 
-    private function placeholder(string $message): JsonResponse
+    private function accessibleWorkspace(Request $request, string $workspace): ?Workspace
     {
-        return ApiResponse::error($message, [], 501);
+        return Workspace::query()
+            ->whereKey($workspace)
+            ->whereHas('teams.users', function ($query) use ($request): void {
+                $query->whereKey($request->user()->id);
+            })
+            ->first();
+    }
+
+    private function forbidden(): JsonResponse
+    {
+        return ApiResponse::error(
+            'Workspace access denied',
+            [
+                'workspace' => ['You do not have access to this workspace.'],
+            ],
+            403
+        );
     }
 }

--- a/apps/api/app/Http/Requests/Domain/StoreCommentRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreCommentRequest.php
@@ -16,6 +16,8 @@ class StoreCommentRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        return [
+            'body' => ['required', 'string'],
+        ];
     }
 }

--- a/apps/api/app/Http/Requests/Domain/StoreCommentRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreCommentRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCommentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreProjectMemberRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreProjectMemberRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreProjectMemberRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $projectId = $this->route('project');
+
+        return [
+            'user_id' => [
+                'required',
+                'integer',
+                Rule::exists('users', 'id'),
+                Rule::unique('project_user', 'user_id')
+                    ->where(fn ($query) => $query->where('project_id', $projectId)),
+            ],
+        ];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreProjectRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreProjectRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Domain;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreProjectRequest extends FormRequest
 {
@@ -16,6 +17,29 @@ class StoreProjectRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        $workspaceId = $this->route('workspace');
+
+        return [
+            'team_id' => [
+                'required',
+                'integer',
+                Rule::exists('teams', 'id')
+                    ->where(fn ($query) => $query
+                        ->where('workspace_id', $workspaceId)
+                        ->whereNull('deleted_at')),
+            ],
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => [
+                'required',
+                'string',
+                'max:255',
+                'alpha_dash:ascii',
+                Rule::unique('projects', 'slug')
+                    ->where(fn ($query) => $query->where('workspace_id', $workspaceId)),
+            ],
+            'description' => ['nullable', 'string'],
+            'starts_at' => ['nullable', 'date'],
+            'ends_at' => ['nullable', 'date', 'after_or_equal:starts_at'],
+        ];
     }
 }

--- a/apps/api/app/Http/Requests/Domain/StoreProjectRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreProjectRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreProjectRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreTaskRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreTaskRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTaskRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreTaskRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreTaskRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Domain;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreTaskRequest extends FormRequest
 {
@@ -16,6 +17,22 @@ class StoreTaskRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        $projectId = $this->route('project');
+
+        return [
+            'task_status_id' => [
+                'required',
+                'integer',
+                Rule::exists('task_statuses', 'id')
+                    ->where(fn ($query) => $query
+                        ->where('project_id', $projectId)
+                        ->whereNull('deleted_at')),
+            ],
+            'assigned_to' => ['nullable', 'integer', Rule::exists('users', 'id')],
+            'title' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'priority' => ['sometimes', 'string', Rule::in(['low', 'medium', 'high', 'urgent'])],
+            'due_date' => ['nullable', 'date'],
+        ];
     }
 }

--- a/apps/api/app/Http/Requests/Domain/StoreTaskStatusRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreTaskStatusRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTaskStatusRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreTaskStatusRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreTaskStatusRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\Domain;
 
+use App\Models\Project;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreTaskStatusRequest extends FormRequest
 {
@@ -16,6 +18,23 @@ class StoreTaskStatusRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        $project = Project::find($this->route('project'));
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => [
+                'required',
+                'string',
+                'max:255',
+                'alpha_dash:ascii',
+                Rule::unique('task_statuses', 'slug')
+                    ->where(fn ($query) => $query
+                        ->where('workspace_id', $project?->workspace_id)
+                        ->where('project_id', $this->route('project'))),
+            ],
+            'color' => ['nullable', 'string', 'max:255'],
+            'position' => ['sometimes', 'integer', 'min:0', 'max:65535'],
+            'is_default' => ['sometimes', 'boolean'],
+        ];
     }
 }

--- a/apps/api/app/Http/Requests/Domain/StoreTeamMemberRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreTeamMemberRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreTeamMemberRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $teamId = $this->route('team');
+
+        return [
+            'user_id' => [
+                'required',
+                'integer',
+                Rule::exists('users', 'id'),
+                Rule::unique('team_user', 'user_id')
+                    ->where(fn ($query) => $query->where('team_id', $teamId)),
+            ],
+        ];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreTeamRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreTeamRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Domain;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreTeamRequest extends FormRequest
 {
@@ -16,6 +17,19 @@ class StoreTeamRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        $workspaceId = $this->route('workspace');
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => [
+                'required',
+                'string',
+                'max:255',
+                'alpha_dash:ascii',
+                Rule::unique('teams', 'slug')
+                    ->where(fn ($query) => $query->where('workspace_id', $workspaceId)),
+            ],
+            'description' => ['nullable', 'string'],
+        ];
     }
 }

--- a/apps/api/app/Http/Requests/Domain/StoreTeamRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreTeamRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTeamRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreWorkspaceRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreWorkspaceRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreWorkspaceRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/StoreWorkspaceRequest.php
+++ b/apps/api/app/Http/Requests/Domain/StoreWorkspaceRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Domain;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreWorkspaceRequest extends FormRequest
 {
@@ -16,6 +17,10 @@ class StoreWorkspaceRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => ['required', 'string', 'max:255', 'alpha_dash:ascii', Rule::unique('workspaces', 'slug')],
+            'description' => ['nullable', 'string'],
+        ];
     }
 }

--- a/apps/api/app/Http/Requests/Domain/UpdateCommentRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateCommentRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCommentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/UpdateCommentRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateCommentRequest.php
@@ -16,6 +16,8 @@ class UpdateCommentRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        return [
+            'body' => ['required', 'string'],
+        ];
     }
 }

--- a/apps/api/app/Http/Requests/Domain/UpdateProjectRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateProjectRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateProjectRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/UpdateProjectRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateProjectRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Domain;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateProjectRequest extends FormRequest
 {
@@ -16,6 +17,33 @@ class UpdateProjectRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        $workspaceId = $this->route('workspace');
+        $projectId = $this->route('project');
+
+        return [
+            'team_id' => [
+                'sometimes',
+                'required',
+                'integer',
+                Rule::exists('teams', 'id')
+                    ->where(fn ($query) => $query
+                        ->where('workspace_id', $workspaceId)
+                        ->whereNull('deleted_at')),
+            ],
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'slug' => [
+                'sometimes',
+                'required',
+                'string',
+                'max:255',
+                'alpha_dash:ascii',
+                Rule::unique('projects', 'slug')
+                    ->where(fn ($query) => $query->where('workspace_id', $workspaceId))
+                    ->ignore($projectId),
+            ],
+            'description' => ['nullable', 'string'],
+            'starts_at' => ['nullable', 'date'],
+            'ends_at' => ['nullable', 'date', 'after_or_equal:starts_at'],
+        ];
     }
 }

--- a/apps/api/app/Http/Requests/Domain/UpdateTaskRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateTaskRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateTaskRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/UpdateTaskRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateTaskRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Domain;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateTaskRequest extends FormRequest
 {
@@ -16,6 +17,23 @@ class UpdateTaskRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        $projectId = $this->route('project');
+
+        return [
+            'task_status_id' => [
+                'sometimes',
+                'required',
+                'integer',
+                Rule::exists('task_statuses', 'id')
+                    ->where(fn ($query) => $query
+                        ->where('project_id', $projectId)
+                        ->whereNull('deleted_at')),
+            ],
+            'assigned_to' => ['nullable', 'integer', Rule::exists('users', 'id')],
+            'title' => ['sometimes', 'required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'priority' => ['sometimes', 'string', Rule::in(['low', 'medium', 'high', 'urgent'])],
+            'due_date' => ['nullable', 'date'],
+        ];
     }
 }

--- a/apps/api/app/Http/Requests/Domain/UpdateTaskStatusRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateTaskStatusRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateTaskStatusRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/UpdateTaskStatusRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateTaskStatusRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\Domain;
 
+use App\Models\Project;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateTaskStatusRequest extends FormRequest
 {
@@ -16,6 +18,26 @@ class UpdateTaskStatusRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        $project = Project::find($this->route('project'));
+        $taskStatusId = $this->route('taskStatus');
+
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'slug' => [
+                'sometimes',
+                'required',
+                'string',
+                'max:255',
+                'alpha_dash:ascii',
+                Rule::unique('task_statuses', 'slug')
+                    ->where(fn ($query) => $query
+                        ->where('workspace_id', $project?->workspace_id)
+                        ->where('project_id', $this->route('project')))
+                    ->ignore($taskStatusId),
+            ],
+            'color' => ['nullable', 'string', 'max:255'],
+            'position' => ['sometimes', 'integer', 'min:0', 'max:65535'],
+            'is_default' => ['sometimes', 'boolean'],
+        ];
     }
 }

--- a/apps/api/app/Http/Requests/Domain/UpdateTeamRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateTeamRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Domain;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateTeamRequest extends FormRequest
 {
@@ -16,6 +17,22 @@ class UpdateTeamRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        $workspaceId = $this->route('workspace');
+        $teamId = $this->route('team');
+
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'slug' => [
+                'sometimes',
+                'required',
+                'string',
+                'max:255',
+                'alpha_dash:ascii',
+                Rule::unique('teams', 'slug')
+                    ->where(fn ($query) => $query->where('workspace_id', $workspaceId))
+                    ->ignore($teamId),
+            ],
+            'description' => ['nullable', 'string'],
+        ];
     }
 }

--- a/apps/api/app/Http/Requests/Domain/UpdateTeamRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateTeamRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateTeamRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/UpdateWorkspaceRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateWorkspaceRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Domain;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateWorkspaceRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/app/Http/Requests/Domain/UpdateWorkspaceRequest.php
+++ b/apps/api/app/Http/Requests/Domain/UpdateWorkspaceRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Domain;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateWorkspaceRequest extends FormRequest
 {
@@ -16,6 +17,19 @@ class UpdateWorkspaceRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [];
+        $workspaceId = $this->route('workspace');
+
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'slug' => [
+                'sometimes',
+                'required',
+                'string',
+                'max:255',
+                'alpha_dash:ascii',
+                Rule::unique('workspaces', 'slug')->ignore($workspaceId),
+            ],
+            'description' => ['nullable', 'string'],
+        ];
     }
 }

--- a/apps/api/app/Http/Resources/CommentResource.php
+++ b/apps/api/app/Http/Resources/CommentResource.php
@@ -17,6 +17,7 @@ class CommentResource extends JsonResource
             'task_id' => $this->task_id,
             'user_id' => $this->user_id,
             'body' => $this->body,
+            'author' => new UserResource($this->whenLoaded('user')),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/apps/api/app/Http/Resources/CommentResource.php
+++ b/apps/api/app/Http/Resources/CommentResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CommentResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'task_id' => $this->task_id,
+            'user_id' => $this->user_id,
+            'body' => $this->body,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/ProjectResource.php
+++ b/apps/api/app/Http/Resources/ProjectResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ProjectResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'workspace_id' => $this->workspace_id,
+            'team_id' => $this->team_id,
+            'created_by' => $this->created_by,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'description' => $this->description,
+            'starts_at' => $this->starts_at,
+            'ends_at' => $this->ends_at,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/ProjectResource.php
+++ b/apps/api/app/Http/Resources/ProjectResource.php
@@ -19,7 +19,6 @@ class ProjectResource extends JsonResource
             'created_by' => $this->created_by,
             'name' => $this->name,
             'slug' => $this->slug,
-            'description' => $this->description,
             'starts_at' => $this->starts_at,
             'ends_at' => $this->ends_at,
             'created_at' => $this->created_at,

--- a/apps/api/app/Http/Resources/TaskResource.php
+++ b/apps/api/app/Http/Resources/TaskResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TaskResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'project_id' => $this->project_id,
+            'task_status_id' => $this->task_status_id,
+            'created_by' => $this->created_by,
+            'assigned_to' => $this->assigned_to,
+            'title' => $this->title,
+            'description' => $this->description,
+            'priority' => $this->priority,
+            'due_date' => $this->due_date,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/TaskStatusResource.php
+++ b/apps/api/app/Http/Resources/TaskStatusResource.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TaskStatusResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'workspace_id' => $this->workspace_id,
+            'project_id' => $this->project_id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'color' => $this->color,
+            'position' => $this->position,
+            'is_default' => $this->is_default,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/TeamResource.php
+++ b/apps/api/app/Http/Resources/TeamResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TeamResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'workspace_id' => $this->workspace_id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'description' => $this->description,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/TeamResource.php
+++ b/apps/api/app/Http/Resources/TeamResource.php
@@ -17,7 +17,6 @@ class TeamResource extends JsonResource
             'workspace_id' => $this->workspace_id,
             'name' => $this->name,
             'slug' => $this->slug,
-            'description' => $this->description,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/apps/api/app/Http/Resources/UserResource.php
+++ b/apps/api/app/Http/Resources/UserResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class UserResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+            'created_at' => $this->created_at,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/WorkspaceResource.php
+++ b/apps/api/app/Http/Resources/WorkspaceResource.php
@@ -16,7 +16,6 @@ class WorkspaceResource extends JsonResource
             'id' => $this->id,
             'name' => $this->name,
             'slug' => $this->slug,
-            'description' => $this->description,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/apps/api/app/Http/Resources/WorkspaceResource.php
+++ b/apps/api/app/Http/Resources/WorkspaceResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class WorkspaceResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'description' => $this->description,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -1,8 +1,14 @@
 <?php
 
 use App\Http\Controllers\Api\AuthController;
+use App\Http\Controllers\Api\CommentController;
 use App\Http\Controllers\Api\EmailVerificationController;
 use App\Http\Controllers\Api\PasswordResetController;
+use App\Http\Controllers\Api\ProjectController;
+use App\Http\Controllers\Api\TaskController;
+use App\Http\Controllers\Api\TaskStatusController;
+use App\Http\Controllers\Api\TeamController;
+use App\Http\Controllers\Api\WorkspaceController;
 use App\Support\ApiResponse;
 use Illuminate\Support\Facades\Route;
 
@@ -24,4 +30,12 @@ Route::middleware(['auth:sanctum', 'not.disabled'])->group(function () {
     Route::post('/logout', [AuthController::class, 'logout']);
     Route::get('/me', [AuthController::class, 'me']);
     Route::post('/email/verification-notification', [EmailVerificationController::class, 'resend']);
+
+    Route::apiResource('workspaces', WorkspaceController::class);
+    Route::apiResource('workspaces.teams', TeamController::class);
+    Route::apiResource('workspaces.projects', ProjectController::class);
+    Route::apiResource('projects.task-statuses', TaskStatusController::class)
+        ->parameters(['task-statuses' => 'taskStatus']);
+    Route::apiResource('projects.tasks', TaskController::class);
+    Route::apiResource('tasks.comments', CommentController::class);
 });

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Api\CommentController;
 use App\Http\Controllers\Api\EmailVerificationController;
 use App\Http\Controllers\Api\PasswordResetController;
 use App\Http\Controllers\Api\ProjectController;
+use App\Http\Controllers\Api\ProjectMemberController;
 use App\Http\Controllers\Api\TaskController;
 use App\Http\Controllers\Api\TaskStatusController;
 use App\Http\Controllers\Api\TeamController;
@@ -37,6 +38,9 @@ Route::middleware(['auth:sanctum', 'not.disabled'])->group(function () {
     Route::post('/workspaces/{workspace}/teams/{team}/members', [TeamMemberController::class, 'store']);
     Route::delete('/workspaces/{workspace}/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy']);
     Route::apiResource('workspaces.teams', TeamController::class);
+    Route::get('/workspaces/{workspace}/projects/{project}/members', [ProjectMemberController::class, 'index']);
+    Route::post('/workspaces/{workspace}/projects/{project}/members', [ProjectMemberController::class, 'store']);
+    Route::delete('/workspaces/{workspace}/projects/{project}/members/{user}', [ProjectMemberController::class, 'destroy']);
     Route::apiResource('workspaces.projects', ProjectController::class);
     Route::apiResource('projects.task-statuses', TaskStatusController::class)
         ->parameters(['task-statuses' => 'taskStatus']);

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Api\ProjectController;
 use App\Http\Controllers\Api\TaskController;
 use App\Http\Controllers\Api\TaskStatusController;
 use App\Http\Controllers\Api\TeamController;
+use App\Http\Controllers\Api\TeamMemberController;
 use App\Http\Controllers\Api\WorkspaceController;
 use App\Support\ApiResponse;
 use Illuminate\Support\Facades\Route;
@@ -32,6 +33,9 @@ Route::middleware(['auth:sanctum', 'not.disabled'])->group(function () {
     Route::post('/email/verification-notification', [EmailVerificationController::class, 'resend']);
 
     Route::apiResource('workspaces', WorkspaceController::class);
+    Route::get('/workspaces/{workspace}/teams/{team}/members', [TeamMemberController::class, 'index']);
+    Route::post('/workspaces/{workspace}/teams/{team}/members', [TeamMemberController::class, 'store']);
+    Route::delete('/workspaces/{workspace}/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy']);
     Route::apiResource('workspaces.teams', TeamController::class);
     Route::apiResource('workspaces.projects', ProjectController::class);
     Route::apiResource('projects.task-statuses', TaskStatusController::class)

--- a/apps/api/tests/Feature/CommentRoutesTest.php
+++ b/apps/api/tests/Feature/CommentRoutesTest.php
@@ -1,0 +1,351 @@
+<?php
+
+use App\Models\Comment;
+use App\Models\Project;
+use App\Models\Task;
+use App\Models\TaskStatus;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects comment routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/tasks/1/comments'],
+    ['POST', '/api/tasks/1/comments'],
+    ['GET', '/api/tasks/1/comments/1'],
+    ['PATCH', '/api/tasks/1/comments/1'],
+    ['DELETE', '/api/tasks/1/comments/1'],
+]);
+
+it('creates a comment for an accessible task', function () {
+    $user = User::factory()->create([
+        'email' => 'comment-create@example.com',
+        'name' => 'Comment Author',
+    ]);
+    [, , $task] = commentEndpointTaskForUser($user);
+
+    commentEndpointLoginAs($user);
+
+    $this->postJson("/api/tasks/{$task->id}/comments", [
+        'body' => 'This task is ready for review.',
+    ])
+        ->assertCreated()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Comment created successfully',
+            'data' => [
+                'task_id' => $task->id,
+                'user_id' => $user->id,
+                'body' => 'This task is ready for review.',
+                'author' => [
+                    'id' => $user->id,
+                    'name' => 'Comment Author',
+                    'email' => 'comment-create@example.com',
+                ],
+            ],
+        ]);
+
+    $this->assertDatabaseHas('comments', [
+        'task_id' => $task->id,
+        'user_id' => $user->id,
+        'body' => 'This task is ready for review.',
+    ]);
+});
+
+it('returns validation errors when creating a comment with invalid data', function () {
+    $user = User::factory()->create([
+        'email' => 'comment-validation@example.com',
+    ]);
+    [, , $task] = commentEndpointTaskForUser($user);
+
+    commentEndpointLoginAs($user);
+
+    $this->postJson("/api/tasks/{$task->id}/comments", [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'body',
+        ]);
+});
+
+it('lists comments for an accessible task', function () {
+    $user = User::factory()->create([
+        'email' => 'comment-index@example.com',
+        'name' => 'Index Author',
+    ]);
+    [, , $task] = commentEndpointTaskForUser($user);
+    $visibleComment = Comment::factory()->create([
+        'task_id' => $task->id,
+        'user_id' => $user->id,
+        'body' => 'Visible comment body.',
+    ]);
+
+    Comment::factory()->create([
+        'body' => 'Hidden comment body.',
+    ]);
+
+    commentEndpointLoginAs($user);
+
+    $this->getJson("/api/tasks/{$task->id}/comments")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Comments retrieved successfully',
+        ])
+        ->assertJsonFragment([
+            'id' => $visibleComment->id,
+            'task_id' => $task->id,
+            'user_id' => $user->id,
+            'body' => 'Visible comment body.',
+        ])
+        ->assertJsonFragment([
+            'id' => $user->id,
+            'name' => 'Index Author',
+            'email' => 'comment-index@example.com',
+        ])
+        ->assertJsonMissing([
+            'body' => 'Hidden comment body.',
+        ]);
+});
+
+it('shows an accessible comment', function () {
+    $user = User::factory()->create([
+        'email' => 'comment-show@example.com',
+        'name' => 'Show Author',
+    ]);
+    [, , $task] = commentEndpointTaskForUser($user);
+    $comment = Comment::factory()->create([
+        'task_id' => $task->id,
+        'user_id' => $user->id,
+        'body' => 'Visible comment.',
+    ]);
+
+    commentEndpointLoginAs($user);
+
+    $this->getJson("/api/tasks/{$task->id}/comments/{$comment->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Comment retrieved successfully',
+            'data' => [
+                'id' => $comment->id,
+                'task_id' => $task->id,
+                'user_id' => $user->id,
+                'body' => 'Visible comment.',
+                'author' => [
+                    'id' => $user->id,
+                    'name' => 'Show Author',
+                    'email' => 'comment-show@example.com',
+                ],
+            ],
+        ]);
+});
+
+it('forbids inaccessible task and comment access', function () {
+    $user = User::factory()->create([
+        'email' => 'comment-forbidden@example.com',
+    ]);
+    [, , $accessibleTask] = commentEndpointTaskForUser($user);
+    $hiddenWorkspace = Workspace::factory()->create();
+    $hiddenTeam = Team::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+    ]);
+    $hiddenProject = Project::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+        'team_id' => $hiddenTeam->id,
+    ]);
+    $hiddenStatus = TaskStatus::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+        'project_id' => $hiddenProject->id,
+    ]);
+    $hiddenTask = Task::factory()->create([
+        'project_id' => $hiddenProject->id,
+        'task_status_id' => $hiddenStatus->id,
+    ]);
+    $hiddenComment = Comment::factory()->create([
+        'task_id' => $hiddenTask->id,
+    ]);
+
+    commentEndpointLoginAs($user);
+
+    $this->getJson("/api/tasks/{$hiddenTask->id}/comments")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Comment access denied',
+            'errors' => [
+                'comment' => ['You do not have access to this comment.'],
+            ],
+        ]);
+
+    $this->getJson("/api/tasks/{$accessibleTask->id}/comments/{$hiddenComment->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Comment access denied',
+        ]);
+});
+
+it('allows the author to update and delete their own comment', function () {
+    $author = User::factory()->create([
+        'email' => 'comment-author@example.com',
+    ]);
+    [, , $task] = commentEndpointTaskForUser($author);
+    $comment = Comment::factory()->create([
+        'task_id' => $task->id,
+        'user_id' => $author->id,
+        'body' => 'Before update.',
+    ]);
+
+    commentEndpointLoginAs($author);
+
+    $this->patchJson("/api/tasks/{$task->id}/comments/{$comment->id}", [
+        'body' => 'After update.',
+    ])
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Comment updated successfully',
+            'data' => [
+                'id' => $comment->id,
+                'body' => 'After update.',
+            ],
+        ]);
+
+    $this->assertDatabaseHas('comments', [
+        'id' => $comment->id,
+        'body' => 'After update.',
+    ]);
+
+    $this->deleteJson("/api/tasks/{$task->id}/comments/{$comment->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Comment deleted successfully',
+            'data' => null,
+        ]);
+
+    $this->assertSoftDeleted('comments', [
+        'id' => $comment->id,
+    ]);
+});
+
+it('forbids non-authors from updating or deleting comments', function () {
+    $author = User::factory()->create([
+        'email' => 'comment-owner@example.com',
+    ]);
+    $otherUser = User::factory()->create([
+        'email' => 'comment-non-author@example.com',
+    ]);
+    [$workspace, , $task] = commentEndpointTaskForUser($author);
+    $otherTeam = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+    $otherTeam->users()->attach($otherUser->id);
+    $comment = Comment::factory()->create([
+        'task_id' => $task->id,
+        'user_id' => $author->id,
+        'body' => 'Original comment.',
+    ]);
+
+    commentEndpointLoginAs($otherUser);
+
+    $this->patchJson("/api/tasks/{$task->id}/comments/{$comment->id}", [
+        'body' => 'Non-author update.',
+    ])
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Comment author required',
+            'errors' => [
+                'comment' => ['Only the comment author can modify this comment.'],
+            ],
+        ]);
+
+    $this->deleteJson("/api/tasks/{$task->id}/comments/{$comment->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Comment author required',
+        ]);
+
+    $this->assertDatabaseHas('comments', [
+        'id' => $comment->id,
+        'body' => 'Original comment.',
+    ]);
+    $this->assertNotSoftDeleted('comments', [
+        'id' => $comment->id,
+    ]);
+});
+
+it('does not expose sensitive author fields in comment responses', function () {
+    $author = User::factory()->create([
+        'email' => 'comment-safe-author@example.com',
+    ]);
+    [, , $task] = commentEndpointTaskForUser($author);
+    $comment = Comment::factory()->create([
+        'task_id' => $task->id,
+        'user_id' => $author->id,
+    ]);
+
+    commentEndpointLoginAs($author);
+
+    $this->getJson("/api/tasks/{$task->id}/comments/{$comment->id}")
+        ->assertOk()
+        ->assertJsonMissingPath('data.author.password')
+        ->assertJsonMissingPath('data.author.remember_token')
+        ->assertJsonMissingPath('data.author.email_verified_at')
+        ->assertJsonMissingPath('data.author.disabled_at')
+        ->assertJsonMissingPath('data.author.roles')
+        ->assertJsonMissingPath('data.author.permissions');
+
+    $this->getJson("/api/tasks/{$task->id}/comments")
+        ->assertOk()
+        ->assertJsonMissingPath('data.0.author.password')
+        ->assertJsonMissingPath('data.0.author.remember_token')
+        ->assertJsonMissingPath('data.0.author.email_verified_at')
+        ->assertJsonMissingPath('data.0.author.disabled_at')
+        ->assertJsonMissingPath('data.0.author.roles')
+        ->assertJsonMissingPath('data.0.author.permissions');
+});
+
+function commentEndpointLoginAs(User $user): void
+{
+    test()->postJson('/api/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertOk();
+}
+
+/**
+ * @return array{Workspace, Project, Task}
+ */
+function commentEndpointTaskForUser(User $user): array
+{
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+    $project = Project::factory()->create([
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'created_by' => $user->id,
+    ]);
+    $status = TaskStatus::factory()->create([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+    ]);
+    $task = Task::factory()->create([
+        'project_id' => $project->id,
+        'task_status_id' => $status->id,
+        'created_by' => $user->id,
+    ]);
+
+    $team->users()->attach($user->id);
+
+    return [$workspace, $project, $task];
+}

--- a/apps/api/tests/Feature/DomainAuthorizationTest.php
+++ b/apps/api/tests/Feature/DomainAuthorizationTest.php
@@ -1,0 +1,328 @@
+<?php
+
+use App\Models\Comment;
+use App\Models\Project;
+use App\Models\Task;
+use App\Models\TaskStatus;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('rejects unauthenticated requests to representative domain routes', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/workspaces'],
+    ['GET', '/api/workspaces/1/teams'],
+    ['GET', '/api/workspaces/1/teams/1/members'],
+    ['GET', '/api/workspaces/1/projects'],
+    ['GET', '/api/workspaces/1/projects/1/members'],
+    ['GET', '/api/projects/1/task-statuses'],
+    ['GET', '/api/projects/1/tasks'],
+    ['GET', '/api/tasks/1/comments'],
+]);
+
+it('rejects disabled users from representative domain routes', function (string $route) {
+    $user = User::factory()->create([
+        'email' => 'domain-disabled@example.com',
+    ]);
+    [$workspace, $team, $project, , $task] = domainAuthorizationGraphForUser($user);
+
+    domainAuthorizationLoginAs($user);
+
+    $user->forceFill([
+        'disabled_at' => now(),
+    ])->save();
+
+    $uri = match ($route) {
+        'workspace' => "/api/workspaces/{$workspace->id}",
+        'team' => "/api/workspaces/{$workspace->id}/teams",
+        'team_member' => "/api/workspaces/{$workspace->id}/teams/{$team->id}/members",
+        'project' => "/api/workspaces/{$workspace->id}/projects",
+        'project_member' => "/api/workspaces/{$workspace->id}/projects/{$project->id}/members",
+        'task_status' => "/api/projects/{$project->id}/task-statuses",
+        'task' => "/api/projects/{$project->id}/tasks",
+        'comment' => "/api/tasks/{$task->id}/comments",
+    };
+
+    $this->getJson($uri)
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Account is disabled',
+            'errors' => [
+                'account' => ['This account has been disabled.'],
+            ],
+        ]);
+})->with([
+    'workspace',
+    'team',
+    'team_member',
+    'project',
+    'project_member',
+    'task_status',
+    'task',
+    'comment',
+]);
+
+it('rejects access to resources in inaccessible workspaces projects and tasks', function () {
+    $user = User::factory()->create([
+        'email' => 'domain-inaccessible@example.com',
+    ]);
+    [$workspace, , $project, , $task] = domainAuthorizationGraphForUser($user);
+    [$hiddenWorkspace, $hiddenTeam, $hiddenProject, $hiddenStatus, $hiddenTask] = domainAuthorizationGraph();
+    $hiddenComment = Comment::factory()->create([
+        'task_id' => $hiddenTask->id,
+    ]);
+
+    domainAuthorizationLoginAs($user);
+
+    $this->getJson("/api/workspaces/{$hiddenWorkspace->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Workspace access denied',
+        ]);
+
+    $this->getJson("/api/workspaces/{$hiddenWorkspace->id}/teams")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+        ]);
+
+    $this->getJson("/api/workspaces/{$workspace->id}/teams/{$hiddenTeam->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+        ]);
+
+    $this->getJson("/api/workspaces/{$workspace->id}/teams/{$hiddenTeam->id}/members")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+        ]);
+
+    $this->getJson("/api/workspaces/{$hiddenWorkspace->id}/projects")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+        ]);
+
+    $this->getJson("/api/workspaces/{$workspace->id}/projects/{$hiddenProject->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+        ]);
+
+    $this->getJson("/api/workspaces/{$workspace->id}/projects/{$hiddenProject->id}/members")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+        ]);
+
+    $this->getJson("/api/projects/{$hiddenProject->id}/task-statuses")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Task status access denied',
+        ]);
+
+    $this->getJson("/api/projects/{$project->id}/task-statuses/{$hiddenStatus->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Task status access denied',
+        ]);
+
+    $this->getJson("/api/projects/{$hiddenProject->id}/tasks")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Task access denied',
+        ]);
+
+    $this->getJson("/api/projects/{$project->id}/tasks/{$hiddenTask->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Task access denied',
+        ]);
+
+    $this->getJson("/api/tasks/{$hiddenTask->id}/comments")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Comment access denied',
+        ]);
+
+    $this->getJson("/api/tasks/{$task->id}/comments/{$hiddenComment->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Comment access denied',
+        ]);
+});
+
+it('rejects nested route mismatches for otherwise accessible resources', function () {
+    $user = User::factory()->create([
+        'email' => 'domain-mismatch@example.com',
+    ]);
+    [$firstWorkspace, , $firstProject, , $firstTask] = domainAuthorizationGraphForUser($user);
+    [, $secondTeam, $secondProject, $secondStatus, $secondTask] = domainAuthorizationGraphForUser($user);
+    $secondComment = Comment::factory()->create([
+        'task_id' => $secondTask->id,
+    ]);
+
+    domainAuthorizationLoginAs($user);
+
+    $this->getJson("/api/workspaces/{$firstWorkspace->id}/teams/{$secondTeam->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+        ]);
+
+    $this->getJson("/api/workspaces/{$firstWorkspace->id}/teams/{$secondTeam->id}/members")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+        ]);
+
+    $this->getJson("/api/workspaces/{$firstWorkspace->id}/projects/{$secondProject->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+        ]);
+
+    $this->getJson("/api/workspaces/{$firstWorkspace->id}/projects/{$secondProject->id}/members")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+        ]);
+
+    $this->getJson("/api/projects/{$firstProject->id}/task-statuses/{$secondStatus->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Task status access denied',
+        ]);
+
+    $this->getJson("/api/projects/{$firstProject->id}/tasks/{$secondTask->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Task access denied',
+        ]);
+
+    $this->getJson("/api/tasks/{$firstTask->id}/comments/{$secondComment->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Comment access denied',
+        ]);
+});
+
+it('rejects non-authors from updating or deleting comments', function () {
+    $author = User::factory()->create([
+        'email' => 'domain-comment-author@example.com',
+    ]);
+    $otherUser = User::factory()->create([
+        'email' => 'domain-comment-other@example.com',
+    ]);
+    [$workspace, , , , $task] = domainAuthorizationGraphForUser($author);
+    $otherTeam = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+    $otherTeam->users()->attach($otherUser->id);
+    $comment = Comment::factory()->create([
+        'task_id' => $task->id,
+        'user_id' => $author->id,
+        'body' => 'Author-owned comment.',
+    ]);
+
+    domainAuthorizationLoginAs($otherUser);
+
+    $this->patchJson("/api/tasks/{$task->id}/comments/{$comment->id}", [
+        'body' => 'Updated by another user.',
+    ])
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Comment author required',
+            'errors' => [
+                'comment' => ['Only the comment author can modify this comment.'],
+            ],
+        ]);
+
+    $this->deleteJson("/api/tasks/{$task->id}/comments/{$comment->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Comment author required',
+        ]);
+
+    $this->assertDatabaseHas('comments', [
+        'id' => $comment->id,
+        'body' => 'Author-owned comment.',
+    ]);
+    $this->assertNotSoftDeleted('comments', [
+        'id' => $comment->id,
+    ]);
+});
+
+function domainAuthorizationLoginAs(User $user): void
+{
+    test()->postJson('/api/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertOk();
+}
+
+/**
+ * @return array{Workspace, Team, Project, TaskStatus, Task}
+ */
+function domainAuthorizationGraphForUser(User $user): array
+{
+    [$workspace, $team, $project, $status, $task] = domainAuthorizationGraph();
+
+    $team->users()->attach($user->id);
+
+    return [$workspace, $team, $project, $status, $task];
+}
+
+/**
+ * @return array{Workspace, Team, Project, TaskStatus, Task}
+ */
+function domainAuthorizationGraph(): array
+{
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+    $project = Project::factory()->create([
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+    ]);
+    $status = TaskStatus::factory()->create([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+    ]);
+    $task = Task::factory()->create([
+        'project_id' => $project->id,
+        'task_status_id' => $status->id,
+    ]);
+
+    return [$workspace, $team, $project, $status, $task];
+}

--- a/apps/api/tests/Feature/DomainRoutesTest.php
+++ b/apps/api/tests/Feature/DomainRoutesTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects domain routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/workspaces'],
+    ['POST', '/api/workspaces'],
+    ['GET', '/api/workspaces/1/teams'],
+    ['GET', '/api/workspaces/1/projects'],
+    ['GET', '/api/projects/1/task-statuses'],
+    ['GET', '/api/projects/1/tasks'],
+    ['GET', '/api/tasks/1/comments'],
+]);
+
+it('blocks disabled authenticated users from domain routes', function () {
+    $user = User::factory()->create([
+        'email' => 'disabled-domain@example.com',
+    ]);
+
+    $this->postJson('/api/login', [
+        'email' => 'disabled-domain@example.com',
+        'password' => 'password',
+    ])->assertOk();
+
+    $user->forceFill([
+        'disabled_at' => now(),
+    ])->save();
+
+    $this->getJson('/api/workspaces')
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Account is disabled',
+            'errors' => [
+                'account' => ['This account has been disabled.'],
+            ],
+        ]);
+});

--- a/apps/api/tests/Feature/ProjectMemberRoutesTest.php
+++ b/apps/api/tests/Feature/ProjectMemberRoutesTest.php
@@ -1,0 +1,256 @@
+<?php
+
+use App\Models\Project;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects project member routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/workspaces/1/projects/1/members'],
+    ['POST', '/api/workspaces/1/projects/1/members'],
+    ['DELETE', '/api/workspaces/1/projects/1/members/1'],
+]);
+
+it('lists project members for an accessible project', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-list-manager@example.com',
+        'name' => 'Manager User',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'project-member-list-member@example.com',
+        'name' => 'Member User',
+    ]);
+    [$workspace, $project] = projectMemberEndpointProjectForUser($manager);
+
+    $project->users()->attach($member->id);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->getJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Project members retrieved successfully',
+        ])
+        ->assertJsonFragment([
+            'id' => $member->id,
+            'name' => 'Member User',
+            'email' => 'project-member-list-member@example.com',
+        ]);
+});
+
+it('adds a member to an accessible project', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-add-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'project-member-add-member@example.com',
+        'name' => 'Added Member',
+    ]);
+    [$workspace, $project] = projectMemberEndpointProjectForUser($manager);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertCreated()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Project member added successfully',
+            'data' => [
+                'id' => $member->id,
+                'name' => 'Added Member',
+                'email' => 'project-member-add-member@example.com',
+            ],
+        ]);
+
+    $this->assertDatabaseHas('project_user', [
+        'project_id' => $project->id,
+        'user_id' => $member->id,
+    ]);
+});
+
+it('returns validation errors when adding an invalid project member', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-validation@example.com',
+    ]);
+    [$workspace, $project] = projectMemberEndpointProjectForUser($manager);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members", [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'user_id',
+        ]);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members", [
+        'user_id' => 999999,
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'user_id',
+        ]);
+});
+
+it('rejects duplicate project membership', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-duplicate-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'project-member-duplicate-member@example.com',
+    ]);
+    [$workspace, $project] = projectMemberEndpointProjectForUser($manager);
+
+    $project->users()->attach($member->id);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'user_id',
+        ]);
+});
+
+it('removes a member from an accessible project', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-remove-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'project-member-remove-member@example.com',
+    ]);
+    [$workspace, $project] = projectMemberEndpointProjectForUser($manager);
+
+    $project->users()->attach($member->id);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->deleteJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members/{$member->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Project member removed successfully',
+            'data' => null,
+        ]);
+
+    $this->assertDatabaseMissing('project_user', [
+        'project_id' => $project->id,
+        'user_id' => $member->id,
+    ]);
+});
+
+it('forbids inaccessible project membership management', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-forbidden-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'project-member-forbidden-member@example.com',
+    ]);
+    [$accessibleWorkspace] = projectMemberEndpointProjectForUser($manager);
+    $hiddenWorkspace = Workspace::factory()->create();
+    $hiddenTeam = Team::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+    ]);
+    $hiddenProject = Project::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+        'team_id' => $hiddenTeam->id,
+    ]);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->getJson("/api/workspaces/{$hiddenWorkspace->id}/projects/{$hiddenProject->id}/members")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+            'errors' => [
+                'project' => ['You do not have access to this project.'],
+            ],
+        ]);
+
+    $this->postJson("/api/workspaces/{$accessibleWorkspace->id}/projects/{$hiddenProject->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+        ]);
+
+    $this->deleteJson("/api/workspaces/{$accessibleWorkspace->id}/projects/{$hiddenProject->id}/members/{$member->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+        ]);
+});
+
+it('does not expose sensitive user fields in project member responses', function () {
+    $manager = User::factory()->create([
+        'email' => 'project-member-safe-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'project-member-safe-member@example.com',
+    ]);
+    [$workspace, $project] = projectMemberEndpointProjectForUser($manager);
+
+    projectMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertCreated()
+        ->assertJsonMissingPath('data.password')
+        ->assertJsonMissingPath('data.remember_token')
+        ->assertJsonMissingPath('data.email_verified_at')
+        ->assertJsonMissingPath('data.disabled_at')
+        ->assertJsonMissingPath('data.roles')
+        ->assertJsonMissingPath('data.permissions');
+
+    $this->getJson("/api/workspaces/{$workspace->id}/projects/{$project->id}/members")
+        ->assertOk()
+        ->assertJsonMissingPath('data.0.password')
+        ->assertJsonMissingPath('data.0.remember_token')
+        ->assertJsonMissingPath('data.0.email_verified_at')
+        ->assertJsonMissingPath('data.0.disabled_at')
+        ->assertJsonMissingPath('data.0.roles')
+        ->assertJsonMissingPath('data.0.permissions');
+});
+
+function projectMemberEndpointLoginAs(User $user): void
+{
+    test()->postJson('/api/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertOk();
+}
+
+/**
+ * @return array{Workspace, Project}
+ */
+function projectMemberEndpointProjectForUser(User $user): array
+{
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+    $project = Project::factory()->create([
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'created_by' => $user->id,
+    ]);
+
+    $team->users()->attach($user->id);
+
+    return [$workspace, $project];
+}

--- a/apps/api/tests/Feature/ProjectRoutesTest.php
+++ b/apps/api/tests/Feature/ProjectRoutesTest.php
@@ -1,0 +1,340 @@
+<?php
+
+use App\Models\Project;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects project routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/workspaces/1/projects'],
+    ['POST', '/api/workspaces/1/projects'],
+    ['GET', '/api/workspaces/1/projects/1'],
+    ['PATCH', '/api/workspaces/1/projects/1'],
+    ['DELETE', '/api/workspaces/1/projects/1'],
+]);
+
+it('creates a project in an accessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'project-create@example.com',
+    ]);
+    [$workspace, $team] = projectEndpointWorkspaceForUser($user);
+
+    projectEndpointLoginAs($user);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects", [
+        'team_id' => $team->id,
+        'name' => 'Billing Portal',
+        'slug' => 'billing-portal',
+        'description' => 'Customer billing work.',
+        'starts_at' => '2026-06-01',
+        'ends_at' => '2026-07-01',
+    ])
+        ->assertCreated()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Project created successfully',
+            'data' => [
+                'workspace_id' => $workspace->id,
+                'team_id' => $team->id,
+                'created_by' => $user->id,
+                'name' => 'Billing Portal',
+                'slug' => 'billing-portal',
+            ],
+        ])
+        ->assertJsonMissingPath('data.description');
+
+    $this->assertDatabaseHas('projects', [
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'created_by' => $user->id,
+        'name' => 'Billing Portal',
+        'slug' => 'billing-portal',
+    ]);
+});
+
+it('returns validation errors when creating a project with invalid data', function () {
+    $user = User::factory()->create([
+        'email' => 'project-validation@example.com',
+    ]);
+    [$workspace] = projectEndpointWorkspaceForUser($user);
+
+    projectEndpointLoginAs($user);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects", [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'team_id',
+            'name',
+            'slug',
+        ]);
+});
+
+it('rejects duplicate project slugs within the same workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'project-duplicate@example.com',
+    ]);
+    [$workspace, $team] = projectEndpointWorkspaceForUser($user);
+
+    Project::factory()->create([
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'slug' => 'duplicate-project',
+    ]);
+
+    projectEndpointLoginAs($user);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/projects", [
+        'team_id' => $team->id,
+        'name' => 'Duplicate Project',
+        'slug' => 'duplicate-project',
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'slug',
+        ]);
+});
+
+it('lists only projects in an accessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'project-index@example.com',
+    ]);
+    [$workspace, $team] = projectEndpointWorkspaceForUser($user);
+    $visibleProject = Project::factory()->create([
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'created_by' => $user->id,
+        'name' => 'Visible Project',
+        'slug' => 'visible-project',
+    ]);
+
+    Project::factory()->create([
+        'name' => 'Hidden Project',
+        'slug' => 'hidden-project',
+    ]);
+
+    projectEndpointLoginAs($user);
+
+    $this->getJson("/api/workspaces/{$workspace->id}/projects")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Projects retrieved successfully',
+        ])
+        ->assertJsonFragment([
+            'id' => $visibleProject->id,
+            'workspace_id' => $workspace->id,
+            'team_id' => $team->id,
+            'created_by' => $user->id,
+            'name' => 'Visible Project',
+            'slug' => 'visible-project',
+        ])
+        ->assertJsonMissing([
+            'slug' => 'hidden-project',
+        ]);
+});
+
+it('shows an accessible project', function () {
+    $user = User::factory()->create([
+        'email' => 'project-show@example.com',
+    ]);
+    [$workspace, $team] = projectEndpointWorkspaceForUser($user);
+    $project = Project::factory()->create([
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'created_by' => $user->id,
+        'name' => 'Visible Project',
+        'slug' => 'visible-project',
+    ]);
+
+    projectEndpointLoginAs($user);
+
+    $this->getJson("/api/workspaces/{$workspace->id}/projects/{$project->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Project retrieved successfully',
+            'data' => [
+                'id' => $project->id,
+                'workspace_id' => $workspace->id,
+                'team_id' => $team->id,
+                'created_by' => $user->id,
+                'name' => 'Visible Project',
+                'slug' => 'visible-project',
+            ],
+        ])
+        ->assertJsonMissingPath('data.description');
+});
+
+it('forbids inaccessible project and workspace access', function () {
+    $user = User::factory()->create([
+        'email' => 'project-show-forbidden@example.com',
+    ]);
+    [$accessibleWorkspace] = projectEndpointWorkspaceForUser($user);
+    $hiddenWorkspace = Workspace::factory()->create();
+    $hiddenTeam = Team::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+    ]);
+    $hiddenProject = Project::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+        'team_id' => $hiddenTeam->id,
+    ]);
+
+    projectEndpointLoginAs($user);
+
+    $this->getJson("/api/workspaces/{$hiddenWorkspace->id}/projects")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+            'errors' => [
+                'project' => ['You do not have access to this project.'],
+            ],
+        ]);
+
+    $this->getJson("/api/workspaces/{$accessibleWorkspace->id}/projects/{$hiddenProject->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+        ]);
+});
+
+it('updates an accessible project', function () {
+    $user = User::factory()->create([
+        'email' => 'project-update@example.com',
+    ]);
+    [$workspace, $team] = projectEndpointWorkspaceForUser($user);
+    $project = Project::factory()->create([
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'created_by' => $user->id,
+        'slug' => 'before-update',
+    ]);
+
+    projectEndpointLoginAs($user);
+
+    $this->patchJson("/api/workspaces/{$workspace->id}/projects/{$project->id}", [
+        'name' => 'After Update',
+        'slug' => 'after-update',
+    ])
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Project updated successfully',
+            'data' => [
+                'id' => $project->id,
+                'workspace_id' => $workspace->id,
+                'team_id' => $team->id,
+                'name' => 'After Update',
+                'slug' => 'after-update',
+            ],
+        ]);
+
+    $this->assertDatabaseHas('projects', [
+        'id' => $project->id,
+        'name' => 'After Update',
+        'slug' => 'after-update',
+    ]);
+});
+
+it('forbids updating an inaccessible project', function () {
+    $user = User::factory()->create([
+        'email' => 'project-update-forbidden@example.com',
+    ]);
+    [$accessibleWorkspace] = projectEndpointWorkspaceForUser($user);
+    $hiddenProject = Project::factory()->create([
+        'name' => 'Do Not Touch',
+    ]);
+
+    projectEndpointLoginAs($user);
+
+    $this->patchJson("/api/workspaces/{$accessibleWorkspace->id}/projects/{$hiddenProject->id}", [
+        'name' => 'Changed Anyway',
+    ])
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+        ]);
+
+    $this->assertDatabaseHas('projects', [
+        'id' => $hiddenProject->id,
+        'name' => 'Do Not Touch',
+    ]);
+});
+
+it('soft deletes an accessible project', function () {
+    $user = User::factory()->create([
+        'email' => 'project-delete@example.com',
+    ]);
+    [$workspace, $team] = projectEndpointWorkspaceForUser($user);
+    $project = Project::factory()->create([
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'created_by' => $user->id,
+    ]);
+
+    projectEndpointLoginAs($user);
+
+    $this->deleteJson("/api/workspaces/{$workspace->id}/projects/{$project->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Project deleted successfully',
+            'data' => null,
+        ]);
+
+    $this->assertSoftDeleted('projects', [
+        'id' => $project->id,
+    ]);
+});
+
+it('forbids deleting an inaccessible project', function () {
+    $user = User::factory()->create([
+        'email' => 'project-delete-forbidden@example.com',
+    ]);
+    [$accessibleWorkspace] = projectEndpointWorkspaceForUser($user);
+    $hiddenProject = Project::factory()->create();
+
+    projectEndpointLoginAs($user);
+
+    $this->deleteJson("/api/workspaces/{$accessibleWorkspace->id}/projects/{$hiddenProject->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Project access denied',
+        ]);
+
+    $this->assertNotSoftDeleted('projects', [
+        'id' => $hiddenProject->id,
+    ]);
+});
+
+function projectEndpointLoginAs(User $user): void
+{
+    test()->postJson('/api/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertOk();
+}
+
+/**
+ * @return array{Workspace, Team}
+ */
+function projectEndpointWorkspaceForUser(User $user): array
+{
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+
+    $team->users()->attach($user->id);
+
+    return [$workspace, $team];
+}

--- a/apps/api/tests/Feature/TaskRoutesTest.php
+++ b/apps/api/tests/Feature/TaskRoutesTest.php
@@ -1,0 +1,368 @@
+<?php
+
+use App\Models\Project;
+use App\Models\Task;
+use App\Models\TaskStatus;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects task routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/projects/1/tasks'],
+    ['POST', '/api/projects/1/tasks'],
+    ['GET', '/api/projects/1/tasks/1'],
+    ['PATCH', '/api/projects/1/tasks/1'],
+    ['DELETE', '/api/projects/1/tasks/1'],
+]);
+
+it('creates a task for an accessible project', function () {
+    $user = User::factory()->create([
+        'email' => 'task-create@example.com',
+    ]);
+    $assignee = User::factory()->create([
+        'email' => 'task-assignee@example.com',
+    ]);
+    [, $project, $status] = taskEndpointProjectForUser($user);
+
+    taskEndpointLoginAs($user);
+
+    $this->postJson("/api/projects/{$project->id}/tasks", [
+        'task_status_id' => $status->id,
+        'assigned_to' => $assignee->id,
+        'title' => 'Build task API',
+        'description' => 'Implement the core task endpoints.',
+        'priority' => 'high',
+        'due_date' => '2026-06-15',
+    ])
+        ->assertCreated()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Task created successfully',
+            'data' => [
+                'project_id' => $project->id,
+                'task_status_id' => $status->id,
+                'created_by' => $user->id,
+                'assigned_to' => $assignee->id,
+                'title' => 'Build task API',
+                'priority' => 'high',
+            ],
+        ]);
+
+    $this->assertDatabaseHas('tasks', [
+        'project_id' => $project->id,
+        'task_status_id' => $status->id,
+        'created_by' => $user->id,
+        'assigned_to' => $assignee->id,
+        'title' => 'Build task API',
+    ]);
+});
+
+it('returns validation errors when creating a task with invalid data', function () {
+    $user = User::factory()->create([
+        'email' => 'task-validation@example.com',
+    ]);
+    [, $project] = taskEndpointProjectForUser($user);
+
+    taskEndpointLoginAs($user);
+
+    $this->postJson("/api/projects/{$project->id}/tasks", [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'task_status_id',
+            'title',
+        ]);
+
+    $this->postJson("/api/projects/{$project->id}/tasks", [
+        'task_status_id' => 999999,
+        'title' => 'Invalid status task',
+        'assigned_to' => 999999,
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'task_status_id',
+            'assigned_to',
+        ]);
+});
+
+it('rejects task statuses from another project', function () {
+    $user = User::factory()->create([
+        'email' => 'task-invalid-status@example.com',
+    ]);
+    [, $project] = taskEndpointProjectForUser($user);
+    [, $otherProject, $otherStatus] = taskEndpointProjectForUser(User::factory()->create());
+
+    taskEndpointLoginAs($user);
+
+    $this->postJson("/api/projects/{$project->id}/tasks", [
+        'task_status_id' => $otherStatus->id,
+        'title' => 'Wrong project status',
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'task_status_id',
+        ]);
+
+    expect($otherProject->id)->not->toBe($project->id);
+});
+
+it('lists tasks for an accessible project', function () {
+    $user = User::factory()->create([
+        'email' => 'task-index@example.com',
+    ]);
+    [, $project, $status] = taskEndpointProjectForUser($user);
+    $visibleTask = Task::factory()->create([
+        'project_id' => $project->id,
+        'task_status_id' => $status->id,
+        'created_by' => $user->id,
+        'title' => 'Visible Task',
+    ]);
+
+    Task::factory()->create([
+        'title' => 'Hidden Task',
+    ]);
+
+    taskEndpointLoginAs($user);
+
+    $this->getJson("/api/projects/{$project->id}/tasks")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Tasks retrieved successfully',
+        ])
+        ->assertJsonFragment([
+            'id' => $visibleTask->id,
+            'project_id' => $project->id,
+            'task_status_id' => $status->id,
+            'created_by' => $user->id,
+            'title' => 'Visible Task',
+        ])
+        ->assertJsonMissing([
+            'title' => 'Hidden Task',
+        ]);
+});
+
+it('shows an accessible task', function () {
+    $user = User::factory()->create([
+        'email' => 'task-show@example.com',
+    ]);
+    [, $project, $status] = taskEndpointProjectForUser($user);
+    $task = Task::factory()->create([
+        'project_id' => $project->id,
+        'task_status_id' => $status->id,
+        'created_by' => $user->id,
+        'title' => 'Visible Task',
+    ]);
+
+    taskEndpointLoginAs($user);
+
+    $this->getJson("/api/projects/{$project->id}/tasks/{$task->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Task retrieved successfully',
+            'data' => [
+                'id' => $task->id,
+                'project_id' => $project->id,
+                'task_status_id' => $status->id,
+                'created_by' => $user->id,
+                'title' => 'Visible Task',
+            ],
+        ]);
+});
+
+it('forbids inaccessible project and task access', function () {
+    $user = User::factory()->create([
+        'email' => 'task-forbidden@example.com',
+    ]);
+    [, $accessibleProject] = taskEndpointProjectForUser($user);
+    $hiddenWorkspace = Workspace::factory()->create();
+    $hiddenTeam = Team::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+    ]);
+    $hiddenProject = Project::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+        'team_id' => $hiddenTeam->id,
+    ]);
+    $hiddenStatus = TaskStatus::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+        'project_id' => $hiddenProject->id,
+    ]);
+    $hiddenTask = Task::factory()->create([
+        'project_id' => $hiddenProject->id,
+        'task_status_id' => $hiddenStatus->id,
+    ]);
+
+    taskEndpointLoginAs($user);
+
+    $this->getJson("/api/projects/{$hiddenProject->id}/tasks")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Task access denied',
+            'errors' => [
+                'task' => ['You do not have access to this task.'],
+            ],
+        ]);
+
+    $this->getJson("/api/projects/{$accessibleProject->id}/tasks/{$hiddenTask->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Task access denied',
+        ]);
+});
+
+it('updates an accessible task', function () {
+    $user = User::factory()->create([
+        'email' => 'task-update@example.com',
+    ]);
+    $assignee = User::factory()->create([
+        'email' => 'task-update-assignee@example.com',
+    ]);
+    [, $project, $status] = taskEndpointProjectForUser($user);
+    $task = Task::factory()->create([
+        'project_id' => $project->id,
+        'task_status_id' => $status->id,
+        'created_by' => $user->id,
+        'title' => 'Before Update',
+    ]);
+
+    taskEndpointLoginAs($user);
+
+    $this->patchJson("/api/projects/{$project->id}/tasks/{$task->id}", [
+        'title' => 'After Update',
+        'assigned_to' => $assignee->id,
+        'priority' => 'urgent',
+    ])
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Task updated successfully',
+            'data' => [
+                'id' => $task->id,
+                'project_id' => $project->id,
+                'task_status_id' => $status->id,
+                'title' => 'After Update',
+                'assigned_to' => $assignee->id,
+                'priority' => 'urgent',
+            ],
+        ]);
+
+    $this->assertDatabaseHas('tasks', [
+        'id' => $task->id,
+        'title' => 'After Update',
+        'assigned_to' => $assignee->id,
+        'priority' => 'urgent',
+    ]);
+});
+
+it('forbids updating an inaccessible task', function () {
+    $user = User::factory()->create([
+        'email' => 'task-update-forbidden@example.com',
+    ]);
+    [, $accessibleProject] = taskEndpointProjectForUser($user);
+    $hiddenTask = Task::factory()->create([
+        'title' => 'Do Not Touch',
+    ]);
+
+    taskEndpointLoginAs($user);
+
+    $this->patchJson("/api/projects/{$accessibleProject->id}/tasks/{$hiddenTask->id}", [
+        'title' => 'Changed Anyway',
+    ])
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Task access denied',
+        ]);
+
+    $this->assertDatabaseHas('tasks', [
+        'id' => $hiddenTask->id,
+        'title' => 'Do Not Touch',
+    ]);
+});
+
+it('soft deletes an accessible task', function () {
+    $user = User::factory()->create([
+        'email' => 'task-delete@example.com',
+    ]);
+    [, $project, $status] = taskEndpointProjectForUser($user);
+    $task = Task::factory()->create([
+        'project_id' => $project->id,
+        'task_status_id' => $status->id,
+        'created_by' => $user->id,
+    ]);
+
+    taskEndpointLoginAs($user);
+
+    $this->deleteJson("/api/projects/{$project->id}/tasks/{$task->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Task deleted successfully',
+            'data' => null,
+        ]);
+
+    $this->assertSoftDeleted('tasks', [
+        'id' => $task->id,
+    ]);
+});
+
+it('forbids deleting an inaccessible task', function () {
+    $user = User::factory()->create([
+        'email' => 'task-delete-forbidden@example.com',
+    ]);
+    [, $accessibleProject] = taskEndpointProjectForUser($user);
+    $hiddenTask = Task::factory()->create();
+
+    taskEndpointLoginAs($user);
+
+    $this->deleteJson("/api/projects/{$accessibleProject->id}/tasks/{$hiddenTask->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Task access denied',
+        ]);
+
+    $this->assertNotSoftDeleted('tasks', [
+        'id' => $hiddenTask->id,
+    ]);
+});
+
+function taskEndpointLoginAs(User $user): void
+{
+    test()->postJson('/api/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertOk();
+}
+
+/**
+ * @return array{Workspace, Project, TaskStatus}
+ */
+function taskEndpointProjectForUser(User $user): array
+{
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+    $project = Project::factory()->create([
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'created_by' => $user->id,
+    ]);
+    $status = TaskStatus::factory()->create([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+    ]);
+
+    $team->users()->attach($user->id);
+
+    return [$workspace, $project, $status];
+}

--- a/apps/api/tests/Feature/TaskStatusRoutesTest.php
+++ b/apps/api/tests/Feature/TaskStatusRoutesTest.php
@@ -1,0 +1,344 @@
+<?php
+
+use App\Models\Project;
+use App\Models\TaskStatus;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects task status routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/projects/1/task-statuses'],
+    ['POST', '/api/projects/1/task-statuses'],
+    ['GET', '/api/projects/1/task-statuses/1'],
+    ['PATCH', '/api/projects/1/task-statuses/1'],
+    ['DELETE', '/api/projects/1/task-statuses/1'],
+]);
+
+it('creates a task status for an accessible project', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-create@example.com',
+    ]);
+    [$workspace, $project] = taskStatusEndpointProjectForUser($user);
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->postJson("/api/projects/{$project->id}/task-statuses", [
+        'name' => 'Ready for Review',
+        'slug' => 'ready-for-review',
+        'color' => '#44aa88',
+        'position' => 2,
+        'is_default' => true,
+    ])
+        ->assertCreated()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Task status created successfully',
+            'data' => [
+                'workspace_id' => $workspace->id,
+                'project_id' => $project->id,
+                'name' => 'Ready for Review',
+                'slug' => 'ready-for-review',
+                'color' => '#44aa88',
+                'position' => 2,
+                'is_default' => true,
+            ],
+        ]);
+
+    $this->assertDatabaseHas('task_statuses', [
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'name' => 'Ready for Review',
+        'slug' => 'ready-for-review',
+    ]);
+});
+
+it('returns validation errors when creating a task status with invalid data', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-validation@example.com',
+    ]);
+    [, $project] = taskStatusEndpointProjectForUser($user);
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->postJson("/api/projects/{$project->id}/task-statuses", [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'name',
+            'slug',
+        ]);
+});
+
+it('rejects duplicate task status slugs in the same project scope', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-duplicate@example.com',
+    ]);
+    [$workspace, $project] = taskStatusEndpointProjectForUser($user);
+
+    TaskStatus::factory()->create([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'slug' => 'duplicate-status',
+    ]);
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->postJson("/api/projects/{$project->id}/task-statuses", [
+        'name' => 'Duplicate Status',
+        'slug' => 'duplicate-status',
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'slug',
+        ]);
+});
+
+it('lists task statuses for an accessible project', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-index@example.com',
+    ]);
+    [$workspace, $project] = taskStatusEndpointProjectForUser($user);
+    $visibleStatus = TaskStatus::factory()->create([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'name' => 'Visible Status',
+        'slug' => 'visible-status',
+        'position' => 1,
+    ]);
+
+    TaskStatus::factory()->create([
+        'name' => 'Hidden Status',
+        'slug' => 'hidden-status',
+    ]);
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->getJson("/api/projects/{$project->id}/task-statuses")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Task statuses retrieved successfully',
+        ])
+        ->assertJsonFragment([
+            'id' => $visibleStatus->id,
+            'workspace_id' => $workspace->id,
+            'project_id' => $project->id,
+            'name' => 'Visible Status',
+            'slug' => 'visible-status',
+        ])
+        ->assertJsonMissing([
+            'slug' => 'hidden-status',
+        ]);
+});
+
+it('shows an accessible task status', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-show@example.com',
+    ]);
+    [$workspace, $project] = taskStatusEndpointProjectForUser($user);
+    $status = TaskStatus::factory()->create([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'name' => 'Visible Status',
+        'slug' => 'visible-status',
+    ]);
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->getJson("/api/projects/{$project->id}/task-statuses/{$status->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Task status retrieved successfully',
+            'data' => [
+                'id' => $status->id,
+                'workspace_id' => $workspace->id,
+                'project_id' => $project->id,
+                'name' => 'Visible Status',
+                'slug' => 'visible-status',
+            ],
+        ]);
+});
+
+it('forbids inaccessible project and task status access', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-forbidden@example.com',
+    ]);
+    [, $accessibleProject] = taskStatusEndpointProjectForUser($user);
+    $hiddenWorkspace = Workspace::factory()->create();
+    $hiddenTeam = Team::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+    ]);
+    $hiddenProject = Project::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+        'team_id' => $hiddenTeam->id,
+    ]);
+    $hiddenStatus = TaskStatus::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+        'project_id' => $hiddenProject->id,
+    ]);
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->getJson("/api/projects/{$hiddenProject->id}/task-statuses")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Task status access denied',
+            'errors' => [
+                'task_status' => ['You do not have access to this task status.'],
+            ],
+        ]);
+
+    $this->getJson("/api/projects/{$accessibleProject->id}/task-statuses/{$hiddenStatus->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Task status access denied',
+        ]);
+});
+
+it('updates an accessible task status', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-update@example.com',
+    ]);
+    [$workspace, $project] = taskStatusEndpointProjectForUser($user);
+    $status = TaskStatus::factory()->create([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'slug' => 'before-update',
+    ]);
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->patchJson("/api/projects/{$project->id}/task-statuses/{$status->id}", [
+        'name' => 'After Update',
+        'slug' => 'after-update',
+        'position' => 4,
+    ])
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Task status updated successfully',
+            'data' => [
+                'id' => $status->id,
+                'workspace_id' => $workspace->id,
+                'project_id' => $project->id,
+                'name' => 'After Update',
+                'slug' => 'after-update',
+                'position' => 4,
+            ],
+        ]);
+
+    $this->assertDatabaseHas('task_statuses', [
+        'id' => $status->id,
+        'name' => 'After Update',
+        'slug' => 'after-update',
+        'position' => 4,
+    ]);
+});
+
+it('forbids updating an inaccessible task status', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-update-forbidden@example.com',
+    ]);
+    [, $accessibleProject] = taskStatusEndpointProjectForUser($user);
+    $hiddenStatus = TaskStatus::factory()->create([
+        'name' => 'Do Not Touch',
+    ]);
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->patchJson("/api/projects/{$accessibleProject->id}/task-statuses/{$hiddenStatus->id}", [
+        'name' => 'Changed Anyway',
+    ])
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Task status access denied',
+        ]);
+
+    $this->assertDatabaseHas('task_statuses', [
+        'id' => $hiddenStatus->id,
+        'name' => 'Do Not Touch',
+    ]);
+});
+
+it('soft deletes an accessible task status', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-delete@example.com',
+    ]);
+    [$workspace, $project] = taskStatusEndpointProjectForUser($user);
+    $status = TaskStatus::factory()->create([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+    ]);
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->deleteJson("/api/projects/{$project->id}/task-statuses/{$status->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Task status deleted successfully',
+            'data' => null,
+        ]);
+
+    $this->assertSoftDeleted('task_statuses', [
+        'id' => $status->id,
+    ]);
+});
+
+it('forbids deleting an inaccessible task status', function () {
+    $user = User::factory()->create([
+        'email' => 'task-status-delete-forbidden@example.com',
+    ]);
+    [, $accessibleProject] = taskStatusEndpointProjectForUser($user);
+    $hiddenStatus = TaskStatus::factory()->create();
+
+    taskStatusEndpointLoginAs($user);
+
+    $this->deleteJson("/api/projects/{$accessibleProject->id}/task-statuses/{$hiddenStatus->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Task status access denied',
+        ]);
+
+    $this->assertNotSoftDeleted('task_statuses', [
+        'id' => $hiddenStatus->id,
+    ]);
+});
+
+function taskStatusEndpointLoginAs(User $user): void
+{
+    test()->postJson('/api/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertOk();
+}
+
+/**
+ * @return array{Workspace, Project}
+ */
+function taskStatusEndpointProjectForUser(User $user): array
+{
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+    $project = Project::factory()->create([
+        'workspace_id' => $workspace->id,
+        'team_id' => $team->id,
+        'created_by' => $user->id,
+    ]);
+
+    $team->users()->attach($user->id);
+
+    return [$workspace, $project];
+}

--- a/apps/api/tests/Feature/TeamMemberRoutesTest.php
+++ b/apps/api/tests/Feature/TeamMemberRoutesTest.php
@@ -1,0 +1,251 @@
+<?php
+
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects team member routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/workspaces/1/teams/1/members'],
+    ['POST', '/api/workspaces/1/teams/1/members'],
+    ['DELETE', '/api/workspaces/1/teams/1/members/1'],
+]);
+
+it('lists team members for an accessible team', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-list-manager@example.com',
+        'name' => 'Manager User',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'team-member-list-member@example.com',
+        'name' => 'Member User',
+    ]);
+    [$workspace, $team] = teamMemberEndpointTeamForUser($manager);
+
+    $team->users()->attach($member->id);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->getJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Team members retrieved successfully',
+        ])
+        ->assertJsonFragment([
+            'id' => $manager->id,
+            'name' => 'Manager User',
+            'email' => 'team-member-list-manager@example.com',
+        ])
+        ->assertJsonFragment([
+            'id' => $member->id,
+            'name' => 'Member User',
+            'email' => 'team-member-list-member@example.com',
+        ]);
+});
+
+it('adds a member to an accessible team', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-add-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'team-member-add-member@example.com',
+        'name' => 'Added Member',
+    ]);
+    [$workspace, $team] = teamMemberEndpointTeamForUser($manager);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertCreated()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Team member added successfully',
+            'data' => [
+                'id' => $member->id,
+                'name' => 'Added Member',
+                'email' => 'team-member-add-member@example.com',
+            ],
+        ]);
+
+    $this->assertDatabaseHas('team_user', [
+        'team_id' => $team->id,
+        'user_id' => $member->id,
+    ]);
+});
+
+it('returns validation errors when adding an invalid team member', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-validation@example.com',
+    ]);
+    [$workspace, $team] = teamMemberEndpointTeamForUser($manager);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members", [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'user_id',
+        ]);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members", [
+        'user_id' => 999999,
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'user_id',
+        ]);
+});
+
+it('rejects duplicate team membership', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-duplicate-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'team-member-duplicate-member@example.com',
+    ]);
+    [$workspace, $team] = teamMemberEndpointTeamForUser($manager);
+
+    $team->users()->attach($member->id);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'user_id',
+        ]);
+});
+
+it('removes a member from an accessible team', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-remove-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'team-member-remove-member@example.com',
+    ]);
+    [$workspace, $team] = teamMemberEndpointTeamForUser($manager);
+
+    $team->users()->attach($member->id);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->deleteJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members/{$member->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Team member removed successfully',
+            'data' => null,
+        ]);
+
+    $this->assertDatabaseMissing('team_user', [
+        'team_id' => $team->id,
+        'user_id' => $member->id,
+    ]);
+});
+
+it('forbids inaccessible team membership management', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-forbidden-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'team-member-forbidden-member@example.com',
+    ]);
+    [$accessibleWorkspace] = teamMemberEndpointTeamForUser($manager);
+    $hiddenWorkspace = Workspace::factory()->create();
+    $hiddenTeam = Team::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+    ]);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->getJson("/api/workspaces/{$hiddenWorkspace->id}/teams/{$hiddenTeam->id}/members")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+            'errors' => [
+                'team' => ['You do not have access to this team.'],
+            ],
+        ]);
+
+    $this->postJson("/api/workspaces/{$accessibleWorkspace->id}/teams/{$hiddenTeam->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+        ]);
+
+    $this->deleteJson("/api/workspaces/{$accessibleWorkspace->id}/teams/{$hiddenTeam->id}/members/{$member->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+        ]);
+});
+
+it('does not expose sensitive user fields in member responses', function () {
+    $manager = User::factory()->create([
+        'email' => 'team-member-safe-manager@example.com',
+    ]);
+    $member = User::factory()->create([
+        'email' => 'team-member-safe-member@example.com',
+    ]);
+    [$workspace, $team] = teamMemberEndpointTeamForUser($manager);
+
+    teamMemberEndpointLoginAs($manager);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members", [
+        'user_id' => $member->id,
+    ])
+        ->assertCreated()
+        ->assertJsonMissingPath('data.password')
+        ->assertJsonMissingPath('data.remember_token')
+        ->assertJsonMissingPath('data.email_verified_at')
+        ->assertJsonMissingPath('data.disabled_at')
+        ->assertJsonMissingPath('data.roles')
+        ->assertJsonMissingPath('data.permissions');
+
+    $this->getJson("/api/workspaces/{$workspace->id}/teams/{$team->id}/members")
+        ->assertOk()
+        ->assertJsonMissingPath('data.0.password')
+        ->assertJsonMissingPath('data.0.remember_token')
+        ->assertJsonMissingPath('data.0.email_verified_at')
+        ->assertJsonMissingPath('data.0.disabled_at')
+        ->assertJsonMissingPath('data.0.roles')
+        ->assertJsonMissingPath('data.0.permissions');
+});
+
+function teamMemberEndpointLoginAs(User $user): void
+{
+    test()->postJson('/api/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertOk();
+}
+
+/**
+ * @return array{Workspace, Team}
+ */
+function teamMemberEndpointTeamForUser(User $user): array
+{
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+
+    $team->users()->attach($user->id);
+
+    return [$workspace, $team];
+}

--- a/apps/api/tests/Feature/TeamRoutesTest.php
+++ b/apps/api/tests/Feature/TeamRoutesTest.php
@@ -1,0 +1,323 @@
+<?php
+
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects team routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/workspaces/1/teams'],
+    ['POST', '/api/workspaces/1/teams'],
+    ['GET', '/api/workspaces/1/teams/1'],
+    ['PATCH', '/api/workspaces/1/teams/1'],
+    ['DELETE', '/api/workspaces/1/teams/1'],
+]);
+
+it('creates a team in an accessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'team-create@example.com',
+    ]);
+
+    $workspace = teamEndpointWorkspaceForUser($user);
+
+    teamEndpointLoginAs($user);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams", [
+        'name' => 'Platform Team',
+        'slug' => 'platform-team',
+        'description' => 'Owns the shared platform.',
+    ])
+        ->assertCreated()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Team created successfully',
+            'data' => [
+                'workspace_id' => $workspace->id,
+                'name' => 'Platform Team',
+                'slug' => 'platform-team',
+            ],
+        ])
+        ->assertJsonMissingPath('data.description');
+
+    $this->assertDatabaseHas('teams', [
+        'workspace_id' => $workspace->id,
+        'name' => 'Platform Team',
+        'slug' => 'platform-team',
+    ]);
+});
+
+it('returns validation errors when creating a team with invalid data', function () {
+    $user = User::factory()->create([
+        'email' => 'team-validation@example.com',
+    ]);
+
+    $workspace = teamEndpointWorkspaceForUser($user);
+
+    teamEndpointLoginAs($user);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams", [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'name',
+            'slug',
+        ]);
+});
+
+it('rejects duplicate team slugs within the same workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'team-duplicate@example.com',
+    ]);
+
+    $workspace = teamEndpointWorkspaceForUser($user);
+
+    Team::factory()->create([
+        'workspace_id' => $workspace->id,
+        'slug' => 'duplicate-team',
+    ]);
+
+    teamEndpointLoginAs($user);
+
+    $this->postJson("/api/workspaces/{$workspace->id}/teams", [
+        'name' => 'Duplicate Team',
+        'slug' => 'duplicate-team',
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'slug',
+        ]);
+});
+
+it('lists teams only for an accessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'team-index@example.com',
+    ]);
+
+    $workspace = teamEndpointWorkspaceForUser($user);
+    $visibleTeam = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+        'name' => 'Visible Team',
+        'slug' => 'visible-team',
+    ]);
+
+    Team::factory()->create([
+        'workspace_id' => Workspace::factory()->create()->id,
+        'name' => 'Hidden Team',
+        'slug' => 'hidden-team',
+    ]);
+
+    teamEndpointLoginAs($user);
+
+    $this->getJson("/api/workspaces/{$workspace->id}/teams")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Teams retrieved successfully',
+        ])
+        ->assertJsonFragment([
+            'id' => $visibleTeam->id,
+            'workspace_id' => $workspace->id,
+            'name' => 'Visible Team',
+            'slug' => 'visible-team',
+        ])
+        ->assertJsonMissing([
+            'slug' => 'hidden-team',
+        ]);
+});
+
+it('shows an accessible team', function () {
+    $user = User::factory()->create([
+        'email' => 'team-show@example.com',
+    ]);
+
+    $workspace = teamEndpointWorkspaceForUser($user);
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+        'name' => 'Visible Team',
+        'slug' => 'visible-team',
+    ]);
+
+    teamEndpointLoginAs($user);
+
+    $this->getJson("/api/workspaces/{$workspace->id}/teams/{$team->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Team retrieved successfully',
+            'data' => [
+                'id' => $team->id,
+                'workspace_id' => $workspace->id,
+                'name' => 'Visible Team',
+                'slug' => 'visible-team',
+            ],
+        ])
+        ->assertJsonMissingPath('data.description');
+});
+
+it('forbids inaccessible workspace and team access', function () {
+    $user = User::factory()->create([
+        'email' => 'team-show-forbidden@example.com',
+    ]);
+
+    $accessibleWorkspace = teamEndpointWorkspaceForUser($user);
+    $hiddenWorkspace = Workspace::factory()->create();
+    $hiddenTeam = Team::factory()->create([
+        'workspace_id' => $hiddenWorkspace->id,
+    ]);
+
+    teamEndpointLoginAs($user);
+
+    $this->getJson("/api/workspaces/{$hiddenWorkspace->id}/teams")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+            'errors' => [
+                'team' => ['You do not have access to this team.'],
+            ],
+        ]);
+
+    $this->getJson("/api/workspaces/{$accessibleWorkspace->id}/teams/{$hiddenTeam->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+        ]);
+});
+
+it('updates an accessible team', function () {
+    $user = User::factory()->create([
+        'email' => 'team-update@example.com',
+    ]);
+
+    $workspace = teamEndpointWorkspaceForUser($user);
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+        'slug' => 'before-update',
+    ]);
+
+    teamEndpointLoginAs($user);
+
+    $this->patchJson("/api/workspaces/{$workspace->id}/teams/{$team->id}", [
+        'name' => 'After Update',
+        'slug' => 'after-update',
+    ])
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Team updated successfully',
+            'data' => [
+                'id' => $team->id,
+                'workspace_id' => $workspace->id,
+                'name' => 'After Update',
+                'slug' => 'after-update',
+            ],
+        ]);
+
+    $this->assertDatabaseHas('teams', [
+        'id' => $team->id,
+        'name' => 'After Update',
+        'slug' => 'after-update',
+    ]);
+});
+
+it('forbids updating an inaccessible team', function () {
+    $user = User::factory()->create([
+        'email' => 'team-update-forbidden@example.com',
+    ]);
+
+    $accessibleWorkspace = teamEndpointWorkspaceForUser($user);
+    $hiddenTeam = Team::factory()->create([
+        'name' => 'Do Not Touch',
+    ]);
+
+    teamEndpointLoginAs($user);
+
+    $this->patchJson("/api/workspaces/{$accessibleWorkspace->id}/teams/{$hiddenTeam->id}", [
+        'name' => 'Changed Anyway',
+    ])
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+        ]);
+
+    $this->assertDatabaseHas('teams', [
+        'id' => $hiddenTeam->id,
+        'name' => 'Do Not Touch',
+    ]);
+});
+
+it('soft deletes an accessible team', function () {
+    $user = User::factory()->create([
+        'email' => 'team-delete@example.com',
+    ]);
+
+    $workspace = teamEndpointWorkspaceForUser($user);
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+
+    teamEndpointLoginAs($user);
+
+    $this->deleteJson("/api/workspaces/{$workspace->id}/teams/{$team->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Team deleted successfully',
+            'data' => null,
+        ]);
+
+    $this->assertSoftDeleted('teams', [
+        'id' => $team->id,
+    ]);
+});
+
+it('forbids deleting an inaccessible team', function () {
+    $user = User::factory()->create([
+        'email' => 'team-delete-forbidden@example.com',
+    ]);
+
+    $accessibleWorkspace = teamEndpointWorkspaceForUser($user);
+    $hiddenTeam = Team::factory()->create();
+
+    teamEndpointLoginAs($user);
+
+    $this->deleteJson("/api/workspaces/{$accessibleWorkspace->id}/teams/{$hiddenTeam->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Team access denied',
+        ]);
+
+    $this->assertNotSoftDeleted('teams', [
+        'id' => $hiddenTeam->id,
+    ]);
+});
+
+function teamEndpointLoginAs(User $user): void
+{
+    test()->postJson('/api/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertOk();
+}
+
+/**
+ * @param array<string, mixed> $attributes
+ */
+function teamEndpointWorkspaceForUser(User $user, array $attributes = []): Workspace
+{
+    $workspace = Workspace::factory()->create($attributes);
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+
+    $team->users()->attach($user->id);
+
+    return $workspace;
+}

--- a/apps/api/tests/Feature/WorkspaceRoutesTest.php
+++ b/apps/api/tests/Feature/WorkspaceRoutesTest.php
@@ -1,0 +1,300 @@
+<?php
+
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('protects workspace routes with Sanctum', function (string $method, string $uri) {
+    $this->json($method, $uri)
+        ->assertUnauthorized();
+})->with([
+    ['GET', '/api/workspaces'],
+    ['POST', '/api/workspaces'],
+    ['GET', '/api/workspaces/1'],
+    ['PATCH', '/api/workspaces/1'],
+    ['DELETE', '/api/workspaces/1'],
+]);
+
+it('creates a workspace and default team for the authenticated user', function () {
+    $user = User::factory()->create([
+        'email' => 'workspace-create@example.com',
+    ]);
+
+    loginAs($user);
+
+    $this->postJson('/api/workspaces', [
+        'name' => 'Product Engineering',
+        'slug' => 'product-engineering',
+        'description' => 'Internal product delivery workspace.',
+    ])
+        ->assertCreated()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Workspace created successfully',
+            'data' => [
+                'name' => 'Product Engineering',
+                'slug' => 'product-engineering',
+            ],
+        ])
+        ->assertJsonMissingPath('data.description');
+
+    $workspace = Workspace::where('slug', 'product-engineering')->firstOrFail();
+
+    $this->assertDatabaseHas('teams', [
+        'workspace_id' => $workspace->id,
+        'name' => 'Default Team',
+        'slug' => 'default-team',
+    ]);
+
+    $team = Team::where('workspace_id', $workspace->id)->firstOrFail();
+
+    $this->assertDatabaseHas('team_user', [
+        'team_id' => $team->id,
+        'user_id' => $user->id,
+    ]);
+});
+
+it('returns validation errors when creating a workspace with invalid data', function () {
+    $user = User::factory()->create([
+        'email' => 'workspace-validation@example.com',
+    ]);
+
+    loginAs($user);
+
+    $this->postJson('/api/workspaces', [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'name',
+            'slug',
+        ]);
+});
+
+it('rejects duplicate workspace slugs', function () {
+    Workspace::factory()->create([
+        'slug' => 'duplicate-workspace',
+    ]);
+
+    $user = User::factory()->create([
+        'email' => 'workspace-duplicate@example.com',
+    ]);
+
+    loginAs($user);
+
+    $this->postJson('/api/workspaces', [
+        'name' => 'Duplicate Workspace',
+        'slug' => 'duplicate-workspace',
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'slug',
+        ]);
+});
+
+it('lists only workspaces accessible through team membership', function () {
+    $user = User::factory()->create([
+        'email' => 'workspace-index@example.com',
+    ]);
+
+    $accessible = workspaceForUser($user, [
+        'name' => 'Accessible Workspace',
+        'slug' => 'accessible-workspace',
+    ]);
+
+    Workspace::factory()->create([
+        'name' => 'Hidden Workspace',
+        'slug' => 'hidden-workspace',
+    ]);
+
+    loginAs($user);
+
+    $this->getJson('/api/workspaces')
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Workspaces retrieved successfully',
+            'data' => [
+                [
+                    'id' => $accessible->id,
+                    'name' => 'Accessible Workspace',
+                    'slug' => 'accessible-workspace',
+                ],
+            ],
+        ])
+        ->assertJsonMissing([
+            'slug' => 'hidden-workspace',
+        ]);
+});
+
+it('shows an accessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'workspace-show@example.com',
+    ]);
+
+    $workspace = workspaceForUser($user, [
+        'name' => 'Visible Workspace',
+        'slug' => 'visible-workspace',
+    ]);
+
+    loginAs($user);
+
+    $this->getJson("/api/workspaces/{$workspace->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Workspace retrieved successfully',
+            'data' => [
+                'id' => $workspace->id,
+                'name' => 'Visible Workspace',
+                'slug' => 'visible-workspace',
+            ],
+        ])
+        ->assertJsonMissingPath('data.description');
+});
+
+it('forbids showing an inaccessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'workspace-show-forbidden@example.com',
+    ]);
+
+    $workspace = Workspace::factory()->create();
+
+    loginAs($user);
+
+    $this->getJson("/api/workspaces/{$workspace->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Workspace access denied',
+            'errors' => [
+                'workspace' => ['You do not have access to this workspace.'],
+            ],
+        ]);
+});
+
+it('updates an accessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'workspace-update@example.com',
+    ]);
+
+    $workspace = workspaceForUser($user, [
+        'slug' => 'before-update',
+    ]);
+
+    loginAs($user);
+
+    $this->patchJson("/api/workspaces/{$workspace->id}", [
+        'name' => 'After Update',
+        'slug' => 'after-update',
+    ])
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Workspace updated successfully',
+            'data' => [
+                'id' => $workspace->id,
+                'name' => 'After Update',
+                'slug' => 'after-update',
+            ],
+        ]);
+
+    $this->assertDatabaseHas('workspaces', [
+        'id' => $workspace->id,
+        'name' => 'After Update',
+        'slug' => 'after-update',
+    ]);
+});
+
+it('forbids updating an inaccessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'workspace-update-forbidden@example.com',
+    ]);
+
+    $workspace = Workspace::factory()->create([
+        'name' => 'Do Not Touch',
+    ]);
+
+    loginAs($user);
+
+    $this->patchJson("/api/workspaces/{$workspace->id}", [
+        'name' => 'Changed Anyway',
+    ])
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Workspace access denied',
+        ]);
+
+    $this->assertDatabaseHas('workspaces', [
+        'id' => $workspace->id,
+        'name' => 'Do Not Touch',
+    ]);
+});
+
+it('soft deletes an accessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'workspace-delete@example.com',
+    ]);
+
+    $workspace = workspaceForUser($user);
+
+    loginAs($user);
+
+    $this->deleteJson("/api/workspaces/{$workspace->id}")
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Workspace deleted successfully',
+            'data' => null,
+        ]);
+
+    $this->assertSoftDeleted('workspaces', [
+        'id' => $workspace->id,
+    ]);
+});
+
+it('forbids deleting an inaccessible workspace', function () {
+    $user = User::factory()->create([
+        'email' => 'workspace-delete-forbidden@example.com',
+    ]);
+
+    $workspace = Workspace::factory()->create();
+
+    loginAs($user);
+
+    $this->deleteJson("/api/workspaces/{$workspace->id}")
+        ->assertForbidden()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Workspace access denied',
+        ]);
+
+    $this->assertNotSoftDeleted('workspaces', [
+        'id' => $workspace->id,
+    ]);
+});
+
+function loginAs(User $user): void
+{
+    test()->postJson('/api/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertOk();
+}
+
+/**
+ * @param array<string, mixed> $attributes
+ */
+function workspaceForUser(User $user, array $attributes = []): Workspace
+{
+    $workspace = Workspace::factory()->create($attributes);
+    $team = Team::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+
+    $team->users()->attach($user->id);
+
+    return $workspace;
+}

--- a/docs/ai-rules.md
+++ b/docs/ai-rules.md
@@ -38,7 +38,9 @@ Use Form Request classes for validation.
 
 Use API Resources for structured responses.
 
-Use Policies for authorization.
+Use explicit backend authorization checks for implemented access rules.
+
+Use Policies, Gates, or services when broader permission behavior is introduced.
 
 Use Services or Actions for business logic.
 
@@ -83,6 +85,8 @@ frontend permission-aware UI if needed
 
 Permission-related changes should include tests.
 
+Do not claim authorization, permission, policy, or workflow coverage unless matching backend tests exist.
+
 ## Frontend Rules
 
 Use TypeScript.
@@ -122,6 +126,10 @@ CHOKIDAR_INTERVAL=1000
 ```
 
 ## Documentation Rules
+
+Durable project files must not use planning labels.
+
+Do not use planning labels in production filenames, test filenames, class names, helper names, or route names.
 
 When changing setup steps, update:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@
 
 ScaffoldIX is a full-stack project management application for small software teams.
 
-The repository is intentionally documentation-heavy because the project is being built in phases. This file separates implemented backend foundation and auth work from planned later architecture.
+The repository is intentionally documentation-heavy so the current backend status, planned work, and implementation rules stay clear as the project grows.
 
 ## Monorepo Structure
 
@@ -32,9 +32,15 @@ Implemented backend responsibilities:
 - Shared API response helper
 - Sanctum-backed registration, login, logout, current-user, email verification, and password reset endpoints
 - Disabled-user auth blocking through `users.disabled_at`
+- Workspace, team, team member, project, project member, task status, task, and comment endpoints
+- Membership-based domain access checks
+- Nested parent-child route validation
+- Author-only comment update and delete checks
 - Eloquent models and relationships
+- Form Requests for auth and domain validation
+- API Resources for structured domain responses
 - Migrations, factories, and seeders
-- Pest smoke and auth feature tests
+- Pest smoke, auth, domain endpoint, membership, comment, and domain authorization tests
 
 ### apps/web
 
@@ -61,21 +67,63 @@ Frontend permissions are for user experience only. Real permission enforcement m
 
 The backend exposes API routes in `apps/api/routes/api.php`.
 
+Laravel `apiResource` update routes accept both `PUT` and `PATCH`; this document lists `PATCH` as the preferred partial-update method.
+
 ```txt
 GET /api/health
 POST /api/register
 POST /api/login
-POST /api/logout
-GET /api/me
-GET /api/verify-email/{id}/{hash}
-POST /api/email/verification-notification
 POST /api/forgot-password
 POST /api/reset-password
+GET /api/verify-email/{id}/{hash}
+POST /api/logout
+GET /api/me
+POST /api/email/verification-notification
+GET /api/workspaces
+POST /api/workspaces
+GET /api/workspaces/{workspace}
+PATCH /api/workspaces/{workspace}
+DELETE /api/workspaces/{workspace}
+GET /api/workspaces/{workspace}/teams
+POST /api/workspaces/{workspace}/teams
+GET /api/workspaces/{workspace}/teams/{team}
+PATCH /api/workspaces/{workspace}/teams/{team}
+DELETE /api/workspaces/{workspace}/teams/{team}
+GET /api/workspaces/{workspace}/teams/{team}/members
+POST /api/workspaces/{workspace}/teams/{team}/members
+DELETE /api/workspaces/{workspace}/teams/{team}/members/{user}
+GET /api/workspaces/{workspace}/projects
+POST /api/workspaces/{workspace}/projects
+GET /api/workspaces/{workspace}/projects/{project}
+PATCH /api/workspaces/{workspace}/projects/{project}
+DELETE /api/workspaces/{workspace}/projects/{project}
+GET /api/workspaces/{workspace}/projects/{project}/members
+POST /api/workspaces/{workspace}/projects/{project}/members
+DELETE /api/workspaces/{workspace}/projects/{project}/members/{user}
+GET /api/projects/{project}/task-statuses
+POST /api/projects/{project}/task-statuses
+GET /api/projects/{project}/task-statuses/{taskStatus}
+PATCH /api/projects/{project}/task-statuses/{taskStatus}
+DELETE /api/projects/{project}/task-statuses/{taskStatus}
+GET /api/projects/{project}/tasks
+POST /api/projects/{project}/tasks
+GET /api/projects/{project}/tasks/{task}
+PATCH /api/projects/{project}/tasks/{task}
+DELETE /api/projects/{project}/tasks/{task}
+GET /api/tasks/{task}/comments
+POST /api/tasks/{task}/comments
+GET /api/tasks/{task}/comments/{comment}
+PATCH /api/tasks/{task}/comments/{comment}
+DELETE /api/tasks/{task}/comments/{comment}
 ```
 
-The health route returns a standardized success response with the app name and current environment.
+The health route is public. Authenticated auth and domain routes use `auth:sanctum` and `not.disabled`.
+
+Laravel `apiResource` update routes accept both `PUT` and `PATCH`; this document lists `PATCH` as the preferred partial-update method.
 
 Auth endpoint details are documented in `docs/auth.md`.
+
+Domain endpoint details are documented in `docs/domain-api.md`.
 
 ### API Responses
 
@@ -84,7 +132,41 @@ Auth endpoint details are documented in `docs/auth.md`.
 - `success($data, $message, $status)`
 - `error($message, $errors, $status)`
 
-The current health endpoint uses `ApiResponse::success(...)`.
+The current health, auth, and domain endpoints use the shared response shape.
+
+### Domain API Structure
+
+Domain controllers live in `apps/api/app/Http/Controllers/Api`.
+
+Current domain controllers:
+
+- `WorkspaceController`
+- `TeamController`
+- `TeamMemberController`
+- `ProjectController`
+- `ProjectMemberController`
+- `TaskStatusController`
+- `TaskController`
+- `CommentController`
+
+Domain validation lives in `apps/api/app/Http/Requests/Domain`.
+
+Domain response serialization uses API Resources in `apps/api/app/Http/Resources`.
+
+### Current Access Model
+
+Current domain authorization is intentionally simple and explicit:
+
+- Protected domain routes require an authenticated Sanctum user who is not disabled.
+- Workspaces are the top-level domain scope.
+- A user can access a workspace when they belong to at least one team in that workspace.
+- Team, project, task status, task, and comment routes check access through the resource's workspace.
+- Nested routes verify parent-child ownership, such as a team belonging to the requested workspace or a task belonging to the requested project.
+- Team membership is managed through `team_user`.
+- Project membership is managed through `project_user`.
+- Comment update and delete require the authenticated user to be the comment author.
+
+The current implementation does not enforce role hierarchy or permission matrix rules.
 
 ### Models And Relationships
 
@@ -94,16 +176,18 @@ The backend includes Eloquent models for:
 - `Workspace`
 - `Team`
 - `Project`
+- `TaskStatus`
 - `Task`
 - `Comment`
 - `Role`
 - `Permission`
-- `TaskStatus`
 
 The implemented model layer covers the main hierarchy:
 
 ```txt
-Workspace -> Teams -> Projects -> Tasks -> Comments
+Workspace -> Teams
+Workspace -> Projects -> Task statuses
+Workspace -> Projects -> Tasks -> Comments
 ```
 
 It also includes role and permission relationships:
@@ -117,7 +201,7 @@ See `docs/database.md` for table-level details.
 
 ### Factories
 
-Factories exist for the core backend models and support database smoke tests and future feature tests.
+Factories exist for the core backend models and support database smoke tests, domain feature tests, and local demo data creation.
 
 ### Seeders
 
@@ -137,6 +221,9 @@ Pest is installed for backend testing. Current backend tests cover:
 - `User` and `Workspace` factory persistence
 - Database seeder demo data
 - Auth feature behavior
+- Workspace, team, project, task status, task, and comment endpoint behavior
+- Team and project membership endpoint behavior
+- Domain authentication, disabled-user blocking, workspace access, nested route mismatch, and comment author checks
 
 See `docs/testing.md` for test commands and current coverage.
 
@@ -144,12 +231,11 @@ See `docs/testing.md` for test commands and current coverage.
 
 The following pieces are planned but not implemented yet:
 
-- Controllers for domain resources
-- API resources
 - Policies and gates
 - Permission service
 - Role hierarchy service
-- Business workflow endpoints
+- Role and permission matrix enforcement
+- Admin-only user management
 - Frontend auth pages
 - Admin dashboard
 - Production deployment
@@ -157,7 +243,7 @@ The following pieces are planned but not implemented yet:
 
 ## Frontend Architecture
 
-The frontend architecture below is planned. Backend auth is implemented, but frontend auth pages and dashboard workflows are not built yet.
+The frontend architecture below is planned. Backend auth and the core domain API are implemented, but frontend auth pages and dashboard workflows are not built yet.
 
 Preferred structure:
 
@@ -212,7 +298,7 @@ The frontend should not:
 
 ## Database Direction
 
-Phase 1 implemented entities:
+Implemented backend entities:
 
 ```txt
 users
@@ -220,6 +306,7 @@ workspaces
 teams
 team_user
 projects
+project_user
 tasks
 task_statuses
 comments
@@ -255,9 +342,9 @@ Backend:  https://api.example.com
 
 ## Authorization
 
-Authorization is planned and is not implemented yet.
+Current domain access checks are implemented in controllers through explicit membership and parent-child queries.
 
-Planned backend enforcement:
+Planned role and permission matrix enforcement:
 
 - Laravel policies
 - Laravel gates where appropriate
@@ -273,15 +360,17 @@ Implemented now:
 1. Backend smoke tests
 2. Seeder smoke tests
 3. Auth feature tests
+4. Domain endpoint tests
+5. Membership endpoint tests
+6. Comment endpoint tests
+7. Domain authorization tests
 
 Planned testing priority:
 
-1. Permission tests
-2. Policy tests
-3. Controller and API workflow tests
-4. Task workflow tests
-5. Frontend smoke tests
-6. Browser/E2E tests
+1. Role and permission matrix tests
+2. Policy tests when policies are introduced
+3. Frontend smoke tests
+4. Browser/E2E tests
 
 ## Deployment Direction
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Phase 2 backend authentication is implemented in the Laravel API using Laravel Sanctum session authentication.
+Backend authentication is implemented in the Laravel API using Laravel Sanctum session authentication.
 
 Implemented auth features:
 
@@ -119,10 +119,10 @@ Covered areas include registration, login, logout, `/api/me`, protected-route re
 
 ## Out Of Scope
 
-Phase 2 auth does not include:
+Current auth does not include:
 
 - Frontend auth pages
-- Team/project/task CRUD
+- Role and permission matrix enforcement
 - Permission policies
 - Admin dashboard
 - Production deployment

--- a/docs/database.md
+++ b/docs/database.md
@@ -2,12 +2,14 @@
 
 ## Overview
 
-Phase 1 implements the backend database foundation for workspaces, teams, projects, tasks, comments, roles, permissions, task statuses, and membership pivots.
+The backend database foundation supports workspaces, teams, projects, task statuses, tasks, comments, roles, permissions, and membership pivots.
 
 Main hierarchy:
 
 ```txt
-Workspace -> Teams -> Projects -> Tasks -> Comments
+Workspace -> Teams
+Workspace -> Projects -> Task statuses
+Workspace -> Projects -> Tasks -> Comments
 ```
 
 Role and permission structure:
@@ -45,6 +47,8 @@ Laravel default support tables also exist, including cache, jobs, sessions, and 
 
 `Project` belongs to a workspace, team, and creator. Projects have many tasks and many users through `project_user`.
 
+`TaskStatus` belongs to a workspace and project. Current task status endpoints are project-scoped.
+
 `Task` belongs to a project, status, creator, and optional assignee. Tasks have many comments.
 
 `Comment` belongs to a task and user.
@@ -55,13 +59,13 @@ Laravel default support tables also exist, including cache, jobs, sessions, and 
 
 ## Pivot Tables
 
-`team_user` stores basic team membership with a unique `team_id` and `user_id` pair.
+`team_user` stores basic team membership with a unique `team_id` and `user_id` pair. Current workspace and domain access checks use team membership as the source of workspace access.
 
-`project_user` stores project membership with a unique `project_id` and `user_id` pair.
+`project_user` stores project membership with a unique `project_id` and `user_id` pair. Current project member endpoints add, list, and remove records from this pivot.
 
 `role_permission` connects roles to permission records with a unique `role_id` and `permission_id` pair.
 
-`team_user_role` assigns one or more roles to a user within a team. It stores `team_id`, `user_id`, and `role_id` and enforces that combination as unique.
+`team_user_role` is reserved for planned team-scoped role assignment. It stores `team_id`, `user_id`, and `role_id` and enforces that combination as unique, but current basic team membership endpoints use `team_user`.
 
 ## Soft Deletes
 

--- a/docs/domain-api.md
+++ b/docs/domain-api.md
@@ -1,0 +1,122 @@
+# Domain API
+
+## Overview
+
+The core domain API is implemented in the Laravel backend under `apps/api`.
+
+Domain routes are registered in `apps/api/routes/api.php` and are protected by:
+
+- `auth:sanctum`
+- `not.disabled`
+
+Responses use the shared `App\Support\ApiResponse` JSON shape and domain resources from `apps/api/app/Http/Resources`.
+
+Laravel `apiResource` update routes accept both `PUT` and `PATCH`; the endpoint tables below list `PATCH` as the preferred partial-update method.
+
+## Current Access Model
+
+The current backend access model is membership-based:
+
+- Workspaces are the top-level domain scope.
+- A user can access a workspace when they belong to at least one team in that workspace.
+- Team, project, task status, task, and comment routes check access through the resource's workspace.
+- Nested routes verify parent-child ownership.
+- Team membership is stored in `team_user`.
+- Project membership is stored in `project_user`.
+- Comment update and delete are limited to the comment author.
+
+Role hierarchy, permission matrix enforcement, policies, gates, and permission services are planned and not implemented yet.
+
+## Workspaces
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/workspaces` | List workspaces accessible through team membership. |
+| `POST` | `/api/workspaces` | Create a workspace and a default team for the authenticated user. |
+| `GET` | `/api/workspaces/{workspace}` | Show an accessible workspace. |
+| `PATCH` | `/api/workspaces/{workspace}` | Update an accessible workspace. |
+| `DELETE` | `/api/workspaces/{workspace}` | Soft delete an accessible workspace. |
+
+## Teams
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/workspaces/{workspace}/teams` | List teams for an accessible workspace. |
+| `POST` | `/api/workspaces/{workspace}/teams` | Create a team in an accessible workspace. |
+| `GET` | `/api/workspaces/{workspace}/teams/{team}` | Show a team that belongs to the workspace. |
+| `PATCH` | `/api/workspaces/{workspace}/teams/{team}` | Update a team that belongs to the workspace. |
+| `DELETE` | `/api/workspaces/{workspace}/teams/{team}` | Soft delete a team that belongs to the workspace. |
+
+## Team Members
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/workspaces/{workspace}/teams/{team}/members` | List users attached to a team. |
+| `POST` | `/api/workspaces/{workspace}/teams/{team}/members` | Attach a user to a team through `team_user`. |
+| `DELETE` | `/api/workspaces/{workspace}/teams/{team}/members/{user}` | Detach a user from a team. |
+
+Team member responses use `UserResource` and do not expose sensitive user fields.
+
+## Projects
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/workspaces/{workspace}/projects` | List projects in an accessible workspace. |
+| `POST` | `/api/workspaces/{workspace}/projects` | Create a project in an accessible workspace. |
+| `GET` | `/api/workspaces/{workspace}/projects/{project}` | Show a project that belongs to the workspace. |
+| `PATCH` | `/api/workspaces/{workspace}/projects/{project}` | Update a project that belongs to the workspace. |
+| `DELETE` | `/api/workspaces/{workspace}/projects/{project}` | Soft delete a project that belongs to the workspace. |
+
+Project creation records the authenticated user as `created_by`.
+
+## Project Members
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/workspaces/{workspace}/projects/{project}/members` | List users attached to a project. |
+| `POST` | `/api/workspaces/{workspace}/projects/{project}/members` | Attach a user to a project through `project_user`. |
+| `DELETE` | `/api/workspaces/{workspace}/projects/{project}/members/{user}` | Detach a user from a project. |
+
+Project member responses use `UserResource` and do not expose sensitive user fields.
+
+## Task Statuses
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/projects/{project}/task-statuses` | List task statuses for an accessible project. |
+| `POST` | `/api/projects/{project}/task-statuses` | Create a task status for an accessible project. |
+| `GET` | `/api/projects/{project}/task-statuses/{taskStatus}` | Show a task status that belongs to the project. |
+| `PATCH` | `/api/projects/{project}/task-statuses/{taskStatus}` | Update a task status that belongs to the project. |
+| `DELETE` | `/api/projects/{project}/task-statuses/{taskStatus}` | Soft delete a task status that belongs to the project. |
+
+Task status creation uses the project's workspace for `workspace_id`.
+
+## Tasks
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/projects/{project}/tasks` | List tasks for an accessible project. |
+| `POST` | `/api/projects/{project}/tasks` | Create a task for an accessible project. |
+| `GET` | `/api/projects/{project}/tasks/{task}` | Show a task that belongs to the project. |
+| `PATCH` | `/api/projects/{project}/tasks/{task}` | Update a task that belongs to the project. |
+| `DELETE` | `/api/projects/{project}/tasks/{task}` | Soft delete a task that belongs to the project. |
+
+Task creation records the authenticated user as `created_by`. Task status validation is scoped to the current project.
+
+## Comments
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/tasks/{task}/comments` | List comments for an accessible task. |
+| `POST` | `/api/tasks/{task}/comments` | Create a comment for an accessible task. |
+| `GET` | `/api/tasks/{task}/comments/{comment}` | Show a comment that belongs to the task. |
+| `PATCH` | `/api/tasks/{task}/comments/{comment}` | Update an authored comment. |
+| `DELETE` | `/api/tasks/{task}/comments/{comment}` | Soft delete an authored comment. |
+
+Comment creation records the authenticated user as `user_id`. Comment responses include safe author data through `UserResource`.
+
+## Validation And Tests
+
+Domain request validation lives in `apps/api/app/Http/Requests/Domain`.
+
+Current backend tests cover domain endpoints, membership behavior, nested resource mismatches, inaccessible resources, disabled-user blocking, and comment author-only modification. See `docs/testing.md` for the test file list and commands.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The permission system is the central technical feature of ScaffoldIX.
+The permission system is a planned central technical feature of ScaffoldIX.
 
 The goal is to support:
 
@@ -22,7 +22,18 @@ Frontend checks only control what the user sees.
 
 They do not provide security.
 
-## Default Roles
+## Current Status
+
+The current backend domain API uses explicit membership-based access checks:
+
+- Workspace access comes from membership in at least one team in the workspace.
+- Team membership is stored in `team_user`.
+- Project membership is stored in `project_user`.
+- Comment update and delete are author-only.
+
+The role and permission matrix described below is planned and is not enforced yet.
+
+## Planned Default Roles
 
 ```txt
 Admin
@@ -33,7 +44,7 @@ Junior
 Viewer
 ```
 
-## Role Levels
+## Planned Role Levels
 
 Each role has an authority level.
 
@@ -56,7 +67,7 @@ A Mid can assign unassigned tasks to himself or to Junior users.
 A Junior cannot assign tasks.
 ```
 
-## Permission Naming
+## Planned Permission Naming
 
 Permissions should use dot notation.
 
@@ -98,7 +109,7 @@ admin.access
 user.disable
 ```
 
-## Backend Enforcement
+## Planned Backend Enforcement
 
 Backend enforcement should use:
 
@@ -119,7 +130,7 @@ TeamPolicy
 RolePolicy
 ```
 
-## Frontend Permission Usage
+## Planned Frontend Permission Usage
 
 Frontend permissions may be used to:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,7 +14,7 @@ Laravel and Composer commands should be run inside the `api` container so they u
 
 ## Existing Tests
 
-The backend includes smoke tests and focused auth feature tests:
+The backend includes smoke tests, auth tests, domain endpoint tests, membership tests, comment tests, and domain authorization tests:
 
 | Test file | What it verifies |
 | --- | --- |
@@ -22,8 +22,18 @@ The backend includes smoke tests and focused auth feature tests:
 | `DatabaseSmokeTest` | `User::factory()->create()` and `Workspace::factory()->create()` persist records. |
 | `SeederSmokeTest` | `DatabaseSeeder` creates demo users, demo workspace, demo project, and `admin.access`. |
 | `AuthRoutesTest` | Registration, login, logout, current user, protected routes, disabled users, email verification, password reset, validation errors, and sensitive-field exclusions. |
+| `DomainRoutesTest` | Representative domain routes require Sanctum auth and block disabled authenticated users. |
+| `WorkspaceRoutesTest` | Workspace create, list, show, update, soft delete, validation, duplicate slug handling, and inaccessible workspace rejection. |
+| `TeamRoutesTest` | Team create, list, show, update, soft delete, validation, duplicate slug handling, and inaccessible workspace/team rejection. |
+| `TeamMemberRoutesTest` | Team member list, add, remove, validation, duplicate membership rejection, inaccessible team rejection, and safe user serialization. |
+| `ProjectRoutesTest` | Project create, list, show, update, soft delete, validation, duplicate slug handling, and inaccessible workspace/project rejection. |
+| `ProjectMemberRoutesTest` | Project member list, add, remove, validation, duplicate membership rejection, inaccessible project rejection, and safe user serialization. |
+| `TaskStatusRoutesTest` | Task status create, list, show, update, soft delete, validation, duplicate slug handling, and inaccessible project/status rejection. |
+| `TaskRoutesTest` | Task create, list, show, update, soft delete, validation, project-scoped status validation, and inaccessible project/task rejection. |
+| `CommentRoutesTest` | Comment create, list, show, author update/delete, non-author rejection, validation, inaccessible task/comment rejection, and safe author serialization. |
+| `DomainAuthorizationTest` | Unauthenticated rejection, disabled-user blocking, inaccessible workspace/resource rejection, nested route mismatch rejection, and comment author enforcement. |
 
-These tests confirm that the backend foundation boots, migrations run, factories persist data, seeders produce the expected demo baseline, and auth behavior works.
+These tests confirm that the backend foundation boots, migrations run, factories persist data, seeders produce the expected demo baseline, auth behavior works, and the current membership-based domain access model is enforced.
 
 Run only auth tests:
 
@@ -31,14 +41,19 @@ Run only auth tests:
 docker compose exec api ./vendor/bin/pest tests/Feature/AuthRoutesTest.php
 ```
 
+Run only domain authorization tests:
+
+```bash
+docker compose exec api ./vendor/bin/pest tests/Feature/DomainAuthorizationTest.php
+```
+
 ## Not Tested Yet
 
 The current backend tests intentionally do not test:
 
-- Permissions
-- Policies
-- Controllers
-- Business workflows
+- Role and permission matrix enforcement
+- Policies and gates
 - Frontend behavior
+- Browser/E2E workflows
 
-Those areas are planned for later phases when the corresponding implementation exists.
+Those areas are planned for later work when the corresponding implementation exists.


### PR DESCRIPTION
## Summary

- Merges the completed backend domain API work from `develop` into `main`.
- Adds authenticated backend APIs for workspaces, teams, team/project memberships, projects, task statuses, tasks, and comments.
- Adds server-side access checks for domain resources.
- Adds feature test coverage for domain endpoints and authorization behavior.
- Updates project documentation and agent instructions to reflect current backend state.

## What changed

The Laravel API now supports the core project-management domain model through protected API endpoints.

Implemented backend areas include:

- Workspace management
- Team management
- Team membership management
- Project management
- Project membership management
- Task status management
- Task management
- Task comments

Protected domain routes use `auth:sanctum` and `not.disabled`.

The current access model is membership-based:

- Workspace access is granted through team membership.
- Nested resources must belong to their route parent.
- Team membership uses `team_user`.
- Project membership uses `project_user`.
- Comment update and delete are author-only.

Documentation was updated to describe current backend behavior, route structure, database assumptions, testing coverage, and planned permission work.

## Testing

- Backend test suite passed with Pest.
- Route list was verified with Artisan.

Latest confirmed backend result:

- 172 tests passed
- 631 assertions

## Notes

- No frontend implementation was added.
- No Docker or environment changes were added.
- No database migrations were added.
- No role or permission matrix enforcement was implemented.
- `team_user_role` remains reserved for later role assignment work.
- Current authorization is intentionally simple and will be expanded in the planned permission system.